### PR TITLE
Multiple resource files support

### DIFF
--- a/crowdin/build.gradle
+++ b/crowdin/build.gradle
@@ -82,7 +82,7 @@ buildscript {
 
 dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.work:work-runtime-ktx:2.2.0"
+    implementation "androidx.work:work-runtime-ktx:2.3.0"
     implementation "com.google.android.material:material:1.0.0"
     implementation "com.squareup.retrofit2:retrofit:2.6.2"
     implementation 'com.squareup.retrofit2:converter-gson:2.6.0'

--- a/crowdin/src/main/java/com/crowdin/platform/data/model/LanguageData.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/model/LanguageData.kt
@@ -15,4 +15,10 @@ internal class LanguageData(var language: String) {
             languageData.plurals.isNotEmpty() -> plurals = languageData.plurals
         }
     }
+
+    fun addNewResources(languageData: LanguageData) {
+        resources.addAll(languageData.resources)
+        arrays.addAll(languageData.arrays)
+        plurals.addAll(languageData.plurals)
+    }
 }

--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/CrowdingRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/CrowdingRepository.kt
@@ -1,0 +1,50 @@
+package com.crowdin.platform.data.remote
+
+import com.crowdin.platform.data.LanguageDataCallback
+import com.crowdin.platform.data.model.ManifestData
+import com.crowdin.platform.data.remote.api.CrowdinDistributionApi
+import com.google.gson.Gson
+import java.net.HttpURLConnection
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+internal abstract class CrowdingRepository(
+    private val crowdinDistributionApi: CrowdinDistributionApi,
+    private val distributionHash: String
+) : BaseRepository() {
+
+    fun getManifest(languageDataCallback: LanguageDataCallback?) {
+        crowdinDistributionApi.getResourceManifest(distributionHash)
+            .enqueue(object : Callback<ResponseBody> {
+
+                override fun onResponse(
+                    call: Call<ResponseBody>,
+                    response: Response<ResponseBody>
+                ) {
+                    val body = response.body()
+                    when {
+                        response.code() == HttpURLConnection.HTTP_OK && body != null -> {
+                            try {
+                                val manifest =
+                                    Gson().fromJson(body.string(), ManifestData::class.java)
+                                onManifestDataReceived(manifest, languageDataCallback)
+                            } catch (throwable: Throwable) {
+                                languageDataCallback?.onFailure(throwable)
+                            }
+                        }
+                    }
+                }
+
+                override fun onFailure(call: Call<ResponseBody>, throwable: Throwable) {
+                    languageDataCallback?.onFailure(throwable)
+                }
+            })
+    }
+
+    abstract fun onManifestDataReceived(
+        manifest: ManifestData,
+        languageDataCallback: LanguageDataCallback?
+    )
+}

--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/CrowdingRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/CrowdingRepository.kt
@@ -1,8 +1,10 @@
 package com.crowdin.platform.data.remote
 
+import androidx.annotation.WorkerThread
 import com.crowdin.platform.data.LanguageDataCallback
 import com.crowdin.platform.data.model.ManifestData
 import com.crowdin.platform.data.remote.api.CrowdinDistributionApi
+import com.crowdin.platform.util.ThreadUtils
 import com.google.gson.Gson
 import java.net.HttpURLConnection
 import okhttp3.ResponseBody
@@ -29,7 +31,9 @@ internal abstract class CrowdingRepository(
                             try {
                                 val manifest =
                                     Gson().fromJson(body.string(), ManifestData::class.java)
-                                onManifestDataReceived(manifest, languageDataCallback)
+                                ThreadUtils.runInBackgroundPool(Runnable {
+                                    onManifestDataReceived(manifest, languageDataCallback)
+                                }, true)
                             } catch (throwable: Throwable) {
                                 languageDataCallback?.onFailure(throwable)
                             }
@@ -43,6 +47,7 @@ internal abstract class CrowdingRepository(
             })
     }
 
+    @WorkerThread
     abstract fun onManifestDataReceived(
         manifest: ManifestData,
         languageDataCallback: LanguageDataCallback?

--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/MappingRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/MappingRepository.kt
@@ -33,24 +33,22 @@ internal class MappingRepository(
         languageDataCallback: LanguageDataCallback?
     ) {
         // Combine all data before save to storage
-        ThreadUtils.runInBackgroundPool(Runnable {
-            val languageData = LanguageData(sourceLanguage)
+        val languageData = LanguageData(sourceLanguage)
 
-            manifest.files.forEach {
-                val filePath = validateFilePath(it, Locale(sourceLanguage))
-                val eTag = eTagMap[filePath]
+        manifest.files.forEach {
+            val filePath = validateFilePath(it, Locale(sourceLanguage))
+            val eTag = eTagMap[filePath]
 
-                val result = requestFileMapping(
-                    eTag,
-                    distributionHash,
-                    filePath,
-                    languageDataCallback
-                )
-                languageData.addNewResources(result)
-            }
+            val result = requestFileMapping(
+                eTag,
+                distributionHash,
+                filePath,
+                languageDataCallback
+            )
+            languageData.addNewResources(result)
+        }
 
-            dataManager.saveMapping(languageData)
-        }, true)
+        dataManager.saveMapping(languageData)
     }
 
     private fun requestFileMapping(
@@ -83,11 +81,6 @@ internal class MappingRepository(
                     "${Throwable("Unexpected http error code $code")}"
                 )
             }
-        }
-
-        result.errorBody()?.let {
-            languageDataCallback?.onFailure(Throwable("Unexpected http error code $code"))
-            Log.d(MappingRepository::class.java.simpleName, "Unexpected http error code $code")
         }
 
         return languageData

--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
@@ -1,96 +1,97 @@
 package com.crowdin.platform.data.remote
 
+import android.util.Log
 import com.crowdin.platform.data.LanguageDataCallback
+import com.crowdin.platform.data.model.LanguageData
 import com.crowdin.platform.data.model.ManifestData
 import com.crowdin.platform.data.parser.Reader
 import com.crowdin.platform.data.remote.api.CrowdinDistributionApi
-import com.google.gson.Gson
+import com.crowdin.platform.util.ThreadUtils
 import java.net.HttpURLConnection
 import java.util.Locale
 import okhttp3.ResponseBody
 import org.xmlpull.v1.XmlPullParserFactory
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
 
 internal class StringDataRemoteRepository(
     private val crowdinDistributionApi: CrowdinDistributionApi,
     private val reader: Reader,
     private val distributionHash: String
-) : BaseRepository() {
+) : CrowdingRepository(
+    crowdinDistributionApi,
+    distributionHash
+) {
 
     override fun fetchData(languageDataCallback: LanguageDataCallback?) {
         getManifest(languageDataCallback)
     }
 
-    private fun getManifest(languageDataCallback: LanguageDataCallback?) {
-        crowdinDistributionApi.getResourceManifest(distributionHash)
-            .enqueue(object : Callback<ResponseBody> {
+    override fun onManifestDataReceived(
+        manifest: ManifestData,
+        languageDataCallback: LanguageDataCallback?
+    ) {
+        // Combine all data before save to storage
+        ThreadUtils.runInBackgroundPool(Runnable {
+            val languageData = LanguageData(Locale.getDefault().toString())
 
-                override fun onResponse(
-                    call: Call<ResponseBody>,
-                    response: Response<ResponseBody>
-                ) {
-                    val body = response.body()
-                    when {
-                        response.code() == HttpURLConnection.HTTP_OK && body != null -> {
-                            try {
-                                val manifest =
-                                    Gson().fromJson(body.string(), ManifestData::class.java)
-                                manifest.files.forEach {
-                                    val filePath = validateFilePath(it, Locale.getDefault())
-                                    val eTag = eTagMap[filePath]
-                                    requestData(
-                                        eTag,
-                                        distributionHash,
-                                        filePath,
-                                        languageDataCallback
-                                    )
-                                }
-                            } catch (throwable: Throwable) {
-                                languageDataCallback?.onFailure(throwable)
-                            }
-                        }
-                    }
-                }
+            manifest.files.forEach {
+                val filePath = validateFilePath(it, Locale.getDefault())
+                val eTag = eTagMap[filePath]
+                val result = requestStringData(
+                    eTag,
+                    distributionHash,
+                    filePath,
+                    languageDataCallback
+                )
+                languageData.addNewResources(result)
+            }
 
-                override fun onFailure(call: Call<ResponseBody>, throwable: Throwable) {
-                    languageDataCallback?.onFailure(throwable)
-                }
-            })
+            ThreadUtils.executeOnMain { languageDataCallback?.onDataLoaded(languageData) }
+        }, true)
     }
 
-    private fun requestData(
+    private fun requestStringData(
         eTag: String?,
         distributionHash: String,
         filePath: String,
         languageDataCallback: LanguageDataCallback?
-    ) {
-        crowdinDistributionApi.getResourceFile(
+    ): LanguageData {
+        var languageData = LanguageData()
+        val result = crowdinDistributionApi.getResourceFile(
             eTag ?: HEADER_ETAG_EMPTY,
             distributionHash,
             filePath
-        ).enqueue(object : Callback<ResponseBody> {
-
-            override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                val body = response.body()
-                when {
-                    response.code() == HttpURLConnection.HTTP_OK && body != null -> {
-                        response.headers()[HEADER_ETAG]?.let { eTag -> eTagMap.put(filePath, eTag) }
-                        val languageData =
-                            reader.parseInput(body.byteStream(), XmlPullParserFactory.newInstance())
-                        languageData.language = Locale.getDefault().toString()
-                        languageDataCallback?.onDataLoaded(languageData)
-                        reader.close()
-                    }
-                    response.code() != HttpURLConnection.HTTP_NOT_MODIFIED ->
-                        languageDataCallback?.onFailure(Throwable("Unexpected http error code ${response.code()}"))
-                }
+        ).execute()
+        val body = result.body()
+        val code = result.code()
+        when {
+            code == HttpURLConnection.HTTP_OK && body != null -> {
+                languageData = onStringDataReceived(
+                    result.headers()[HEADER_ETAG],
+                    filePath,
+                    body
+                )
             }
+            code != HttpURLConnection.HTTP_NOT_MODIFIED ->
+                languageDataCallback?.onFailure(Throwable("Unexpected http error code $code"))
+        }
+        result.errorBody()?.let {
+            languageDataCallback?.onFailure(Throwable("Unexpected http error code $code"))
+            Log.d(MappingRepository::class.java.simpleName, "Unexpected http error code $code")
+        }
 
-            override fun onFailure(call: Call<ResponseBody>, throwable: Throwable) {
-                languageDataCallback?.onFailure(throwable)
-            }
-        })
+        return languageData
+    }
+
+    private fun onStringDataReceived(
+        eTag: String?,
+        filePath: String,
+        body: ResponseBody
+    ): LanguageData {
+        eTag?.let { eTagMap.put(filePath, eTag) }
+
+        val languageData = reader.parseInput(body.byteStream(), XmlPullParserFactory.newInstance())
+        reader.close()
+
+        return languageData
     }
 }

--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
@@ -1,6 +1,5 @@
 package com.crowdin.platform.data.remote
 
-import android.util.Log
 import com.crowdin.platform.data.LanguageDataCallback
 import com.crowdin.platform.data.model.LanguageData
 import com.crowdin.platform.data.model.ManifestData
@@ -30,23 +29,21 @@ internal class StringDataRemoteRepository(
         languageDataCallback: LanguageDataCallback?
     ) {
         // Combine all data before save to storage
-        ThreadUtils.runInBackgroundPool(Runnable {
-            val languageData = LanguageData(Locale.getDefault().toString())
+        val languageData = LanguageData(Locale.getDefault().toString())
 
-            manifest.files.forEach {
-                val filePath = validateFilePath(it, Locale.getDefault())
-                val eTag = eTagMap[filePath]
-                val result = requestStringData(
-                    eTag,
-                    distributionHash,
-                    filePath,
-                    languageDataCallback
-                )
-                languageData.addNewResources(result)
-            }
+        manifest.files.forEach {
+            val filePath = validateFilePath(it, Locale.getDefault())
+            val eTag = eTagMap[filePath]
+            val result = requestStringData(
+                eTag,
+                distributionHash,
+                filePath,
+                languageDataCallback
+            )
+            languageData.addNewResources(result)
+        }
 
-            ThreadUtils.executeOnMain { languageDataCallback?.onDataLoaded(languageData) }
-        }, true)
+        ThreadUtils.executeOnMain { languageDataCallback?.onDataLoaded(languageData) }
     }
 
     private fun requestStringData(
@@ -73,10 +70,6 @@ internal class StringDataRemoteRepository(
             }
             code != HttpURLConnection.HTTP_NOT_MODIFIED ->
                 languageDataCallback?.onFailure(Throwable("Unexpected http error code $code"))
-        }
-        result.errorBody()?.let {
-            languageDataCallback?.onFailure(Throwable("Unexpected http error code $code"))
-            Log.d(MappingRepository::class.java.simpleName, "Unexpected http error code $code")
         }
 
         return languageData

--- a/crowdin/src/main/java/com/crowdin/platform/util/ThreadUtils.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/util/ThreadUtils.kt
@@ -1,5 +1,6 @@
 package com.crowdin.platform.util
 
+import android.os.Handler
 import android.os.Looper
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingDeque
@@ -66,6 +67,12 @@ internal object ThreadUtils {
             runnable.run()
         } else {
             sLocalWorkPool?.execute(runnable)
+        }
+    }
+
+    fun executeOnMain(function: () -> Unit?) {
+        Handler(Looper.getMainLooper()).post {
+            function.invoke()
         }
     }
 }


### PR DESCRIPTION
[Description]
- extract similar logic from remote repositories to base crowding repository;
- use thread pool for load all data and then save result in one transaction;
- update work library version;
- update Unit tests for Mapping/StringData remote repositories;