### PR TITLE
[#82] Escaped symbols;

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/data/parser/StringResourceParser.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/parser/StringResourceParser.kt
@@ -82,14 +82,14 @@ internal class StringResourceParser : Parser {
             (isArrayStarted && isInnerTagOpened) ||
             (isPluralStarted && isItemStarted && isInnerTagOpened)
         ) {
-            content += parser.text
+            content += parser.text.replace("\\", "")
         } else if (isArrayStarted && isItemStarted) {
             when (arrayData?.values) {
                 null -> arrayData?.values = arrayOf(parser.text)
                 else -> arrayData?.values = arrayData?.values?.plus(parser.text)
             }
         } else if (isPluralStarted && isItemStarted) {
-            content += parser.text
+            content += parser.text.replace("\\", "")
         }
     }
 


### PR DESCRIPTION
[RC]
- XML parser doesn't expect escaped symbols and treat `\"` as a simple string which results in escaped `\\\"` when stored locally. And shown as `\"` when set string to TextView.  

[Fix]
- remove backslashes during xml file parsing before store to local storage;