### PR TITLE
[#109] - RealTime updates not working when delete text and re-enter;

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
@@ -111,18 +111,30 @@ internal class DataManager(
     ) {
         if (FeatureFlags.isRealTimeUpdateEnabled || FeatureFlags.isScreenshotEnabled) {
             when {
-                stringData != null -> localRepository.setStringData(
-                    Locale.getDefault().getFormattedCode() + SUF_COPY,
-                    stringData
-                )
-                arrayData != null -> localRepository.setArrayData(
-                    Locale.getDefault().getFormattedCode() + SUF_COPY,
-                    arrayData
-                )
-                pluralData != null -> localRepository.setPluralData(
-                    Locale.getDefault().getFormattedCode() + SUF_COPY,
-                    pluralData
-                )
+                stringData != null -> {
+                    if (localRepository.containsKey(stringData.stringKey)) {
+                        localRepository.setStringData(
+                            Locale.getDefault().getFormattedCode() + SUF_COPY,
+                            stringData
+                        )
+                    }
+                }
+                arrayData != null -> {
+                    if (localRepository.containsKey(arrayData.name)) {
+                        localRepository.setArrayData(
+                            Locale.getDefault().getFormattedCode() + SUF_COPY,
+                            arrayData
+                        )
+                    }
+                }
+                pluralData != null -> {
+                    if (localRepository.containsKey(pluralData.name)) {
+                        localRepository.setPluralData(
+                            Locale.getDefault().getFormattedCode() + SUF_COPY,
+                            pluralData
+                        )
+                    }
+                }
             }
         }
     }

--- a/crowdin/src/main/java/com/crowdin/platform/data/local/LocalRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/local/LocalRepository.kt
@@ -95,6 +95,14 @@ internal interface LocalRepository {
     fun isExist(language: String): Boolean
 
     /**
+     * Returns <tt>true</tt> if repository contains resource key.
+     *
+     * @param key to compare.
+     * @return true if exist, otherwise false.
+     */
+    fun containsKey(key: String): Boolean
+
+    /**
      * Retrieves text related meta data.
      *
      * @param text searchable text.

--- a/crowdin/src/main/java/com/crowdin/platform/data/local/MemoryLocalRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/local/MemoryLocalRepository.kt
@@ -118,6 +118,28 @@ internal class MemoryLocalRepository : LocalRepository {
         return stringsData[language] != null
     }
 
+    override fun containsKey(key: String): Boolean {
+        stringsData[Locale.getDefault().getFormattedCode()]?.let { languageData ->
+            languageData.resources.forEach {
+                if (it.stringKey == key) {
+                    return true
+                }
+            }
+            languageData.plurals.forEach {
+                if (it.name == key) {
+                    return true
+                }
+            }
+            languageData.arrays.forEach {
+                if (it.name == key) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
     override fun getTextData(text: String): TextMetaData {
         val textMetaData = TextMetaData()
 

--- a/crowdin/src/main/java/com/crowdin/platform/data/local/SharedPrefLocalRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/local/SharedPrefLocalRepository.kt
@@ -74,6 +74,8 @@ internal class SharedPrefLocalRepository internal constructor(
 
     override fun isExist(language: String): Boolean = memoryLocalRepository.isExist(language)
 
+    override fun containsKey(key: String): Boolean = memoryLocalRepository.containsKey(key)
+
     override fun getTextData(text: String): TextMetaData = memoryLocalRepository.getTextData(text)
 
     override fun saveData(type: String, data: Any?) {

--- a/crowdin/src/test/java/com/crowdin/platform/DataManagerTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/DataManagerTest.kt
@@ -134,6 +134,7 @@ class DataManagerTest {
         val mockStringData = mock(StringData::class.java)
         Locale.setDefault(Locale.US)
         val expectedLanguage = Locale.getDefault().getFormattedCode() + "-copy"
+        `when`(mockLocalRepository.containsKey(any())).thenReturn(true)
 
         // When
         dataManager.saveReserveResources(mockStringData)
@@ -152,6 +153,7 @@ class DataManagerTest {
         val mockArrayData = mock(ArrayData::class.java)
         Locale.setDefault(Locale.US)
         val expectedLanguage = Locale.getDefault().getFormattedCode() + "-copy"
+        `when`(mockLocalRepository.containsKey(any())).thenReturn(true)
 
         // When
         dataManager.saveReserveResources(arrayData = mockArrayData)
@@ -170,6 +172,7 @@ class DataManagerTest {
         val mockPluralData = mock(PluralData::class.java)
         Locale.setDefault(Locale.US)
         val expectedLanguage = Locale.getDefault().getFormattedCode() + "-copy"
+        `when`(mockLocalRepository.containsKey(any())).thenReturn(true)
 
         // When
         dataManager.saveReserveResources(pluralData = mockPluralData)

--- a/crowdin/src/test/java/com/crowdin/platform/MemoryLocalRepositoryTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/MemoryLocalRepositoryTest.kt
@@ -284,6 +284,64 @@ class MemoryLocalRepositoryTest {
         assertThat(textMetaData.arrayIndex, `is`(expectedIndex))
     }
 
+    @Test
+    fun whenStringResourceHasKey_containsShouldReturnTrue() {
+        // Given
+        val memoryLocalRepository = MemoryLocalRepository()
+        val key = "test key"
+        val stringData = StringData(key, "empty")
+        memoryLocalRepository.setStringData(Locale.getDefault().getFormattedCode(), stringData)
+
+        // When
+        val actualValue = memoryLocalRepository.containsKey(key)
+
+        // Then
+        assertThat(actualValue, `is`(true))
+    }
+
+    @Test
+    fun whenArrayResourceHasKey_containsShouldReturnTrue() {
+        // Given
+        val memoryLocalRepository = MemoryLocalRepository()
+        val key = "test key"
+        val arrayData = ArrayData(key, null)
+        memoryLocalRepository.setArrayData(Locale.getDefault().getFormattedCode(), arrayData)
+
+        // When
+        val actualValue = memoryLocalRepository.containsKey(key)
+
+        // Then
+        assertThat(actualValue, `is`(true))
+    }
+
+    @Test
+    fun whenPluralResourceHasKey_containsShouldReturnTrue() {
+        // Given
+        val memoryLocalRepository = MemoryLocalRepository()
+        val key = "test key"
+        val pluralData = PluralData(key)
+        memoryLocalRepository.setPluralData(Locale.getDefault().getFormattedCode(), pluralData)
+
+        // When
+        val actualValue = memoryLocalRepository.containsKey(key)
+
+        // Then
+        assertThat(actualValue, `is`(true))
+    }
+
+    @Test
+    fun whenStringResourceEmpty_containsShouldReturnFalse() {
+        // Given
+        val memoryLocalRepository = MemoryLocalRepository()
+        val key = "test key"
+
+        // When
+        val actualValue = memoryLocalRepository.containsKey(key)
+
+        // Then
+        assertThat(actualValue, `is`(false))
+    }
+
     private fun givenLanguageData(locale: String): LanguageData {
         val languageData = LanguageData(locale)
         val listOfStringData = mutableListOf(

--- a/crowdin/src/test/java/com/crowdin/platform/SharedPrefLocalRepositoryTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/SharedPrefLocalRepositoryTest.kt
@@ -202,6 +202,19 @@ class SharedPrefLocalRepositoryTest {
     }
 
     @Test
+    fun containsKeyTest() {
+        // Given
+        val sharedPrefLocalRepository =
+            SharedPrefLocalRepository(context, mockMemoryLocalRepository)
+
+        // When
+        sharedPrefLocalRepository.containsKey("key")
+
+        // Then
+        verify(mockMemoryLocalRepository).containsKey("key")
+    }
+
+    @Test
     fun getTextDataTest() {
         // Given
         val sharedPrefLocalRepository =


### PR DESCRIPTION
[RC]
- system string resources where added to local repository which breaks logic of mapping TextView with string resource;
In some cases this resources treated as an application resource and subscribed for events as a result Views will not be updated anymore;

[Fix]
- save copy resources only when they exist in original resources. Skip all system strings;
- add new test cases;