### PR TITLE
[#105] - RuntimeException: Illegal callback invocation from native module;

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
@@ -232,10 +232,7 @@ internal class DataManager(
                     }
 
                     override fun onFailure(throwable: Throwable) {
-                        ThreadUtils.executeOnMain {
-                            callback.onDataReceived("")
-                            sendOnFailure(throwable)
-                        }
+                        ThreadUtils.executeOnMain { sendOnFailure(throwable) }
                     }
                 })
         }, true)


### PR DESCRIPTION
[RC]
- callback invoked two times.

[FIX]
- remove successful callback invocation from failure method. Empty string will be delivered inside of `onDataLoaded` method;