### PR TITLE
register screenshot observer in README's Java example

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ You can take a screenshots and automatically upload them tagged to Crowdin in tw
               .withUpdateInterval(interval_in_seconds)                                 // optional
               .build());
    }
+
+   // Using system buttons to take screenshots and automatically upload them to Crowdin.
+   Crowdin.registerScreenShotContentObserver(this);
    ```
    </details>
 


### PR DESCRIPTION
Similar to the Kotlin example to take screenshots using the system buttons, the appropriate call should be added to the Java example.