### PR TITLE
Fixed crash on startup 

### DIFF
--- a/crowdin-controls/src/main/java/com/crowdin/crowdin_controls/CrowdinWidgetService.kt
+++ b/crowdin-controls/src/main/java/com/crowdin/crowdin_controls/CrowdinWidgetService.kt
@@ -266,7 +266,10 @@ class CrowdinWidgetService : Service(), LoadingStateListener {
 
         fun destroyService(activity: Activity) {
             activity.stopService(Intent(activity, CrowdinWidgetService::class.java))
-            activity.unregisterReceiver(receiver)
+
+            if (this::receiver.isInitialized) {
+                activity.unregisterReceiver(receiver)
+            }
         }
     }
 }


### PR DESCRIPTION
**[RC]**

Without required permission "android.permission.SYSTEM_ALERT_WINDOW" app was crashed on devices with Android API 23.

**[Fix]**

Using save methods for working with activity and broadcast receiver inside Widget Service