### PR TITLE
[#149] Proguard config;

### DIFF
--- a/crowdin-controls/build.gradle
+++ b/crowdin-controls/build.gradle
@@ -42,7 +42,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-rules.pro'
         }
     }
 

--- a/crowdin-controls/consumer-rules.pro
+++ b/crowdin-controls/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.crowdin.crowdin_controls.** { *; }

--- a/crowdin/build.gradle
+++ b/crowdin/build.gradle
@@ -47,7 +47,7 @@ android {
 
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-rules.pro'
         }
     }
 

--- a/crowdin/consumer-rules.pro
+++ b/crowdin/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.crowdin.platform.** { *; }

--- a/example-info/build.gradle
+++ b/example-info/build.gradle
@@ -17,8 +17,12 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+
+        debug {
+            debuggable true
         }
     }
     compileOptions {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -16,8 +16,12 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+
+        debug {
+            debuggable true
         }
     }
 


### PR DESCRIPTION
- disable obfuscation for sdk internally;

Projects that have dependency on sdk will use proguard config from library. Currently we don't obfuscate code and keep all files.