### PR TITLE
CrowdinBaseContextWrappingDelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,12 @@ To integrate SDK with your application you need to follow step by step instructi
    <summary>Kotlin</summary>
 
    ```kotlin
-   override fun getDelegate() = BaseContextWrappingDelegate(super.getDelegate())
+    private var delegate: AppCompatDelegate? = null
+
+    override fun getDelegate(): AppCompatDelegate = delegate
+        ?: BaseContextWrappingDelegate(super.getDelegate()).also {
+            delegate = it
+        }
    ```
    </details>
 
@@ -123,10 +128,15 @@ To integrate SDK with your application you need to follow step by step instructi
    <summary>Java</summary>
 
    ```java
+   private AppCompatDelegate delegate = null;
+
    @NonNull
    @Override
    public AppCompatDelegate getDelegate() {
-       return new BaseContextWrappingDelegate(super.getDelegate());
+       if (delegate == null) {
+           delegate = new CrowdinBaseContextWrappingDelegate(super.getDelegate());
+       }
+       return delegate;
    }
    ```
    </details>

--- a/crowdin/src/main/java/androidx/appcompat/app/CrowdinBaseContextWrappingDelegate.kt
+++ b/crowdin/src/main/java/androidx/appcompat/app/CrowdinBaseContextWrappingDelegate.kt
@@ -11,7 +11,7 @@ import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.Toolbar
 import com.crowdin.platform.Crowdin
 
-class BaseContextWrappingDelegate(private val superDelegate: AppCompatDelegate) :
+class CrowdinBaseContextWrappingDelegate(private val superDelegate: AppCompatDelegate) :
     AppCompatDelegate() {
 
     override fun getSupportActionBar() = superDelegate.supportActionBar

--- a/example-info/src/main/java/com/example/example_info/InfoActivity.kt
+++ b/example-info/src/main/java/com/example/example_info/InfoActivity.kt
@@ -2,17 +2,22 @@ package com.example.example_info
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.BaseContextWrappingDelegate
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.app.CrowdinBaseContextWrappingDelegate
 
 class InfoActivity : AppCompatActivity() {
 
+    private var delegate: AppCompatDelegate? = null
     /**
      * We should wrap the base context of our activities, which is better to put it
      * on BaseActivity, so that we don't have to repeat it for all activities one-by-one.
      *
-     * @see BaseContextWrappingDelegate.attachBaseContext2
+     * @see CrowdinBaseContextWrappingDelegate.attachBaseContext2
      */
-    override fun getDelegate() = BaseContextWrappingDelegate(super.getDelegate())
+    override fun getDelegate() = delegate
+            ?: CrowdinBaseContextWrappingDelegate(super.getDelegate()).also {
+                delegate = it
+            }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/example/src/main/java/com/crowdin/platform/example/BaseActivity.kt
+++ b/example/src/main/java/com/crowdin/platform/example/BaseActivity.kt
@@ -1,7 +1,8 @@
 package com.crowdin.platform.example
 
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.BaseContextWrappingDelegate
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.app.CrowdinBaseContextWrappingDelegate
 import com.crowdin.crowdin_controls.OverlayActivityContract
 import com.crowdin.crowdin_controls.destroyCrowdinControl
 import com.crowdin.crowdin_controls.initCrowdinControl
@@ -10,13 +11,17 @@ abstract class BaseActivity : AppCompatActivity() {
 
     var overlayPermissionActivityLauncher = registerForActivityResult(OverlayActivityContract()) { }
 
+    private var delegate: AppCompatDelegate? = null
     /**
      * We should wrap the base context of our activities, which is better to put it
      * on BaseActivity, so that we don't have to repeat it for all activities one-by-one.
      *
-     * @see BaseContextWrappingDelegate.attachBaseContext2
+     * @see CrowdinBaseContextWrappingDelegate.attachBaseContext2
      */
-    override fun getDelegate() = BaseContextWrappingDelegate(super.getDelegate())
+    override fun getDelegate() = delegate
+            ?: CrowdinBaseContextWrappingDelegate(super.getDelegate()).also {
+                delegate = it
+            }
 
     override fun onResume() {
         super.onResume()


### PR DESCRIPTION
* Rename BaseContextWrappingDelegate to CrowdinBaseContextWrappingDelegate to avoid duplicate class names with other android libraries.
* Update README and example project to cache delegate.

https://github.com/crowdin/mobile-sdk-android/issues/165