### PR TITLE
Modifies maps with text view's as keys to use weak hash maps

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/realtimeupdate/EchoWebSocketListener.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/realtimeupdate/EchoWebSocketListener.kt
@@ -17,9 +17,9 @@ import com.crowdin.platform.util.ThreadUtils
 import com.crowdin.platform.util.fromHtml
 import com.crowdin.platform.util.unEscapeQuotes
 import com.google.gson.Gson
-import java.lang.ref.WeakReference
+import java.util.Collections
 import java.util.Locale
-import java.util.concurrent.ConcurrentHashMap
+import java.util.WeakHashMap
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 
@@ -30,7 +30,7 @@ internal class EchoWebSocketListener(
     private var languageCode: String
 ) : WebSocketListener() {
 
-    private var dataHolderMap = ConcurrentHashMap<WeakReference<TextView>, TextMetaData>()
+    private var dataHolderMap = Collections.synchronizedMap(WeakHashMap<TextView, TextMetaData>())
 
     override fun onOpen(webSocket: WebSocket, response: okhttp3.Response) {
         output("onOpen")
@@ -90,7 +90,7 @@ internal class EchoWebSocketListener(
             mapping.value?.let {
                 textMetaData.mappingValue = it
                 textMetaData.isHint = mapping.isHint
-                dataHolderMap.put(WeakReference(entry.key), textMetaData)
+                dataHolderMap.put(entry.key, textMetaData)
             }
         }
     }
@@ -154,11 +154,11 @@ internal class EchoWebSocketListener(
 
     private fun updateMatchedView(
         eventData: EventResponse.EventData,
-        mutableEntry: MutableMap.MutableEntry<WeakReference<TextView>, TextMetaData>,
+        mutableEntry: MutableMap.MutableEntry<TextView, TextMetaData>,
         textMetaData: TextMetaData
     ) {
         val text = eventData.text
-        val view = mutableEntry.key.get()
+        val view = mutableEntry.key
 
         if (eventData.pluralForm == null || eventData.pluralForm == PLURAL_NONE) {
             updateViewText(view, text, textMetaData.isHint)

--- a/crowdin/src/main/java/com/crowdin/platform/transformer/BaseTransformer.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/transformer/BaseTransformer.kt
@@ -6,7 +6,8 @@ import android.widget.TextView
 import android.widget.ToggleButton
 import com.crowdin.platform.data.model.TextMetaData
 import com.crowdin.platform.data.model.ViewData
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Collections
+import java.util.WeakHashMap
 
 internal abstract class BaseTransformer : Transformer {
 
@@ -18,7 +19,7 @@ internal abstract class BaseTransformer : Transformer {
     }
 
     var listener: ViewsChangeListener? = null
-    private val createdViews = ConcurrentHashMap<TextView, TextMetaData>()
+    private val createdViews = Collections.synchronizedMap(WeakHashMap<TextView, TextMetaData>())
 
     override fun invalidate() {
         for (createdView in createdViews) {
@@ -66,7 +67,7 @@ internal abstract class BaseTransformer : Transformer {
         return listViewData
     }
 
-    override fun getVisibleViewsWithData(): ConcurrentHashMap<TextView, TextMetaData> {
+    override fun getVisibleViewsWithData(): Map<TextView, TextMetaData> {
         return createdViews
     }
 

--- a/crowdin/src/main/java/com/crowdin/platform/transformer/ViewTransformerManager.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/transformer/ViewTransformerManager.kt
@@ -5,8 +5,8 @@ import android.view.View
 import android.widget.TextView
 import com.crowdin.platform.data.model.TextMetaData
 import com.crowdin.platform.data.model.ViewData
-import java.util.ArrayList
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Collections
+import java.util.WeakHashMap
 
 /**
  * Manages all view transformers as a central point for layout inflater.
@@ -64,8 +64,8 @@ internal class ViewTransformerManager {
         return mutableList
     }
 
-    fun getVisibleViewsWithData(): ConcurrentHashMap<TextView, TextMetaData> {
-        val concurrentHashMap = ConcurrentHashMap<TextView, TextMetaData>()
+    fun getVisibleViewsWithData(): Map<TextView, TextMetaData> {
+        val concurrentHashMap = Collections.synchronizedMap(WeakHashMap<TextView, TextMetaData>())
         transformers.forEach {
             concurrentHashMap.putAll(it.second.getVisibleViewsWithData())
         }
@@ -119,7 +119,7 @@ internal interface Transformer {
      *
      * @return ConcurrentHashMap<TextView, TextMetaData> map of views and text metadata.
      */
-    fun getVisibleViewsWithData(): ConcurrentHashMap<TextView, TextMetaData>
+    fun getVisibleViewsWithData(): Map<TextView, TextMetaData>
 
     /**
      * Set view change listener.


### PR DESCRIPTION
Also, uses `Collections.synchronizedMap` to maintain thread safety.

Fixes #167