### PR TITLE
Fix duplicated API calls during synchronized mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,23 @@ You can set file export patterns and check existing ones using *File Settings*. 
    Also, there are other public methods in `Crowdin` class. You can find details in `kotlin doc` files.
 
 9. Synchronous mode. You can trigger force upload from Crowdin while launching Splash Activity and after that open Main Activity
+
+   App.kt:
+
+   ```kotlin
+   override fun onCreate() {
+       super.onCreate()
+
+       Crowdin.init(applicationContext,
+           CrowdinConfig.Builder()
+               .withDistributionHash(your_distribution_hash)
+               .withInitSyncDisabled()  // Initial data synchronization should be disabled in this case.
+               .build())
+   }
+   ```
+
+    YourActivity.kt:
+
     ```kotlin
     override fun onCreate(savedInstanceState: Bundle?) {
         Crowdin.forceUpdate(this) {

--- a/crowdin/src/main/java/com/crowdin/platform/Crowdin.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/Crowdin.kt
@@ -80,6 +80,11 @@ object Crowdin {
         initTranslationDataManager()
         initRealTimeUpdates()
         initPeriodicUpdates(context)
+
+        if (config.updateInterval == -1L && config.isInitSyncEnabled && !FeatureFlags.isRealTimeUpdateEnabled) {
+            forceUpdate(context)
+        }
+
         loadMapping()
     }
 
@@ -87,12 +92,7 @@ object Crowdin {
         when {
             config.updateInterval >= RecurringManager.MIN_PERIODIC_INTERVAL_MILLIS ->
                 RecurringManager.setPeriodicUpdates(context, config)
-            else -> {
-                RecurringManager.cancel(context)
-                if (!FeatureFlags.isRealTimeUpdateEnabled) {
-                    forceUpdate(context)
-                }
-            }
+            else -> RecurringManager.cancel(context)
         }
     }
 

--- a/crowdin/src/main/java/com/crowdin/platform/CrowdinConfig.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/CrowdinConfig.kt
@@ -18,6 +18,7 @@ class CrowdinConfig private constructor() {
     var updateInterval: Long = -1
     var sourceLanguage: String = ""
     var authConfig: AuthConfig? = null
+    var isInitSyncEnabled: Boolean = true
 
     class Builder {
 
@@ -29,6 +30,7 @@ class CrowdinConfig private constructor() {
         private var updateInterval: Long = -1
         private var sourceLanguage: String = ""
         private var authConfig: AuthConfig? = null
+        private var isInitSyncEnabled: Boolean = true
 
         fun persist(isPersist: Boolean): Builder {
             this.isPersist = isPersist
@@ -70,6 +72,11 @@ class CrowdinConfig private constructor() {
             return this
         }
 
+        fun withInitSyncDisabled(): Builder {
+            this.isInitSyncEnabled = false
+            return this
+        }
+
         fun build(): CrowdinConfig {
             val config = CrowdinConfig()
             config.isPersist = isPersist
@@ -105,6 +112,7 @@ class CrowdinConfig private constructor() {
                 }
             }
             config.authConfig = authConfig
+            config.isInitSyncEnabled = isInitSyncEnabled
 
             return config
         }

--- a/crowdin/src/test/java/com/crowdin/platform/CrowdinConfigTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/CrowdinConfigTest.kt
@@ -159,4 +159,16 @@ class CrowdinConfigTest {
         // Then
         Assert.assertTrue(config.authConfig?.requestAuthDialog == true)
     }
+
+    @Test
+    fun whenInitSyncDisabled_isInitSyncEnabledShouldBeFalse() {
+        // When
+        val config = CrowdinConfig.Builder()
+            .withDistributionHash("distributionHash")
+            .withInitSyncDisabled()
+            .build()
+
+        // Then
+        Assert.assertTrue(config.isInitSyncEnabled == false)
+    }
 }

--- a/example/src/main/java/com/crowdin/platform/example/App.kt
+++ b/example/src/main/java/com/crowdin/platform/example/App.kt
@@ -60,7 +60,8 @@ class App : Application() {
                         organizationName = organizationName,
                         requestAuthDialog = true
                     )
-                )                                                                       // optional
+                )
+                .withInitSyncDisabled()                                                 // optional
                 .build()
         )
 


### PR DESCRIPTION
- update init sync. logic to remove duplicated API calls;
- add new config property to disable default initialization with synchronization;
- readme update;