### PR TITLE
fix: preventing crashes during real time preview

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
@@ -296,7 +296,7 @@ internal class DataManager(
             return ticketValue
         } catch (throwable: Throwable) {
             Log.e(CROWDIN_TAG, "Ticket failed", throwable)
-            return ""
+            return null
         }
     }
 

--- a/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
@@ -272,27 +272,32 @@ internal class DataManager(
 
     @WorkerThread
     fun getTicket(event: String): String? {
-        var ticketValue: String? = null
-        val type = object : TypeToken<MutableMap<String, TicketItem>>() {}.type
-        var ticketsMap: MutableMap<String, TicketItem>? = localRepository.getData(EVENT_TICKETS, type)
-        if (ticketsMap == null) {
-            ticketsMap = mutableMapOf()
-        }
-
-        val ticketItem = ticketsMap[event]
-        if (ticketItem == null || ticketItem.isExpired()) {
-            Log.d(CROWDIN_TAG, "Ticket expired for event: $event")
-            remoteRepository.getTicket(event)?.data?.ticket?.let {
-                ticketsMap[event] = TicketItem(it, System.currentTimeMillis() + EVENT_TICKETS_EXPIRATION)
-                localRepository.saveData(EVENT_TICKETS, ticketsMap)
-                ticketValue = it
+        try {
+            var ticketValue: String? = null
+            val type = object : TypeToken<MutableMap<String, TicketItem>>() {}.type
+            var ticketsMap: MutableMap<String, TicketItem>? = localRepository.getData(EVENT_TICKETS, type)
+            if (ticketsMap == null) {
+                ticketsMap = mutableMapOf()
             }
-        } else {
-            Log.d(CROWDIN_TAG, "Ticket not expired for event: $event")
-            ticketValue = ticketItem.ticket
-        }
 
-        return ticketValue
+            val ticketItem = ticketsMap[event]
+            if (ticketItem == null || ticketItem.isExpired()) {
+                Log.d(CROWDIN_TAG, "Ticket expired for event: $event")
+                remoteRepository.getTicket(event)?.data?.ticket?.let {
+                    ticketsMap[event] = TicketItem(it, System.currentTimeMillis() + EVENT_TICKETS_EXPIRATION)
+                    localRepository.saveData(EVENT_TICKETS, ticketsMap)
+                    ticketValue = it
+                }
+            } else {
+                Log.d(CROWDIN_TAG, "Ticket not expired for event: $event")
+                ticketValue = ticketItem.ticket
+            }
+
+            return ticketValue
+        } catch (throwable: Throwable) {
+            Log.e(CROWDIN_TAG, "Ticket failed", throwable)
+            return ""
+        }
     }
 
     fun clearSocketData() {

--- a/crowdin/src/main/java/com/crowdin/platform/realtimeupdate/EchoWebSocketListener.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/realtimeupdate/EchoWebSocketListener.kt
@@ -80,6 +80,7 @@ internal class EchoWebSocketListener(
         webSocket: WebSocket,
         text: String,
     ) {
+        Log.d(Crowdin.CROWDIN_TAG, "EchoWebSocket. onMessage: $text")
         handleMessage(text)
     }
 
@@ -120,9 +121,13 @@ internal class EchoWebSocketListener(
         project: DistributionInfoResponse.DistributionData.ProjectData,
         user: DistributionInfoResponse.DistributionData.UserData,
     ) {
-        for (viewDataHolder in dataHolderMap) {
-            val mappingValue = viewDataHolder.value.mappingValue
-            subscribeView(webSocket, project, user, mappingValue)
+        try {
+            for (viewDataHolder in dataHolderMap) {
+                val mappingValue = viewDataHolder.value.mappingValue
+                subscribeView(webSocket, project, user, mappingValue)
+            }
+        } catch (exception: Exception) {
+            Log.e(Crowdin.CROWDIN_TAG, "EchoWebSocketListener Exception", exception)
         }
     }
 
@@ -137,8 +142,8 @@ internal class EchoWebSocketListener(
             dataManager.getTicket(updateEvent)?.let {
                 webSocket.send(getSubscribeEventJson(updateEvent, it))
             }
-        } catch (e: Exception) {
-            Log.e(Crowdin.CROWDIN_TAG, "Get ticket for update event failed", e)
+        } catch (throwable: Throwable) {
+            Log.e(Crowdin.CROWDIN_TAG, "Get ticket for update event failed", throwable)
         }
 
         try {
@@ -146,8 +151,8 @@ internal class EchoWebSocketListener(
             dataManager.getTicket(suggestionEvent)?.let {
                 webSocket.send(getSubscribeEventJson(suggestionEvent, it))
             }
-        } catch (e: Exception) {
-            Log.e(Crowdin.CROWDIN_TAG, "Get ticket for suggestion event failed", e)
+        } catch (throwable: Throwable) {
+            Log.e(Crowdin.CROWDIN_TAG, "Get ticket for suggestion event failed", throwable)
         }
     }
 

--- a/crowdin/src/main/java/com/crowdin/platform/transformer/ViewTransformerManager.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/transformer/ViewTransformerManager.kt
@@ -1,8 +1,10 @@
 package com.crowdin.platform.transformer
 
 import android.util.AttributeSet
+import android.util.Log
 import android.view.View
 import android.widget.TextView
+import com.crowdin.platform.Crowdin
 import com.crowdin.platform.data.model.TextMetaData
 import com.crowdin.platform.data.model.ViewData
 import java.util.Collections
@@ -67,8 +69,12 @@ internal class ViewTransformerManager {
 
     fun getVisibleViewsWithData(): Map<TextView, TextMetaData> {
         val concurrentHashMap = Collections.synchronizedMap(WeakHashMap<TextView, TextMetaData>())
-        transformers.forEach {
-            concurrentHashMap.putAll(it.second.getVisibleViewsWithData())
+        try {
+            transformers.forEach {
+                concurrentHashMap.putAll(it.second.getVisibleViewsWithData())
+            }
+        } catch (throwable: Throwable) {
+            Log.e(Crowdin.CROWDIN_TAG, "ViewTransformerManager exception", throwable)
         }
 
         return concurrentHashMap


### PR DESCRIPTION

### **Description**
We planned to implement Crowdin with Real-Time Preview feature. In the process we had encountered crashes and Real-Time was not working. Starting with version 1.13.0 we were able to get the WebSocket to work.

I have prevented crashes that at least avoid closing the app. Also these changes do not generate any issues while Real Time is enabled. This will allow us to be able to deploy our implementation in production.

I am not completely sure that preventing these crashes generates any malfunction, at least for us it is working.

I have also added a log to capture the change coming through `EchoWebSocketListener`.

I have modified `Exception` to `Throwable` since I have caught another crash with an assertion that inherits from `Error`, not `Exception`.

**This is my first contribution, I hope not to infringe your guidelines and code of conduct. All feedback is welcome.**

---
### **Screenshots**
<img src="https://github.com/user-attachments/assets/45e9dbd7-55ca-40f3-a531-432621389eb3" width="800" alt="">

<img src="https://github.com/user-attachments/assets/32cb32bb-2d3e-41ea-a412-32e1ae1e5911" width="800" alt="">

<img src="https://github.com/user-attachments/assets/99310db8-ed37-4a8d-95b2-862f3d0558c3" width="800" alt="">
