### PR TITLE
feat: Use API token for Realtime preview authorization

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/Crowdin.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/Crowdin.kt
@@ -334,7 +334,7 @@ object Crowdin {
             val newHash = config.distributionHash
             it.saveDistributionHash(newHash)
 
-            return it.isAuthorized() && (oldHash == null || oldHash == newHash)
+            return (config.apiAuthConfig?.apiToken != null || it.isAuthorized()) && (oldHash == null || oldHash == newHash)
         }
 
         return false


### PR DESCRIPTION
• Added API token check in the isAuthorized method. If a token is provided, it will be used for the Realtime preview functionality; otherwise, it will fall back to the default OAuth.