### PR TITLE
fix: catch NotFoundException in CrowdinResources for non-app resource IDs

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
@@ -123,11 +123,14 @@ internal class CrowdinResources(
         id: Int,
         quantity: Int,
     ): CharSequence {
-        val plural = getPluralFromRepository(id, quantity)
-        val formattedPlural = plural?.fromHtml() ?: res.getQuantityText(id, quantity)
-        savePluralToCopy(id, quantity, formattedPlural.toString())
-
-        return formattedPlural
+        return try {
+            val plural = getPluralFromRepository(id, quantity)
+            val formattedPlural = plural?.fromHtml() ?: res.getQuantityText(id, quantity)
+            savePluralToCopy(id, quantity, formattedPlural.toString())
+            formattedPlural
+        } catch (_: NotFoundException) {
+            super.getQuantityText(id, quantity)
+        }
     }
 
     @Throws(NotFoundException::class)
@@ -136,21 +139,23 @@ internal class CrowdinResources(
         quantity: Int,
         vararg formatArgs: Any?,
     ): String {
-        val plural = getPluralFromRepository(id, quantity)
-        val formattedPlural =
-            if (plural == null) {
-                res.getQuantityString(id, quantity, *formatArgs)
-            } else {
-                try {
-                    String.format(plural, *formatArgs)
-                } catch (ex: Exception) {
+        return try {
+            val plural = getPluralFromRepository(id, quantity)
+            val formattedPlural =
+                if (plural == null) {
                     res.getQuantityString(id, quantity, *formatArgs)
+                } else {
+                    try {
+                        String.format(plural, *formatArgs)
+                    } catch (_: Exception) {
+                        res.getQuantityString(id, quantity, *formatArgs)
+                    }
                 }
-            }
-
-        savePluralToCopy(id, quantity, formattedPlural, formatArgs)
-
-        return formattedPlural
+            savePluralToCopy(id, quantity, formattedPlural, formatArgs)
+            formattedPlural
+        } catch (_: NotFoundException) {
+            super.getQuantityString(id, quantity, *formatArgs)
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
@@ -237,12 +242,14 @@ internal class CrowdinResources(
         id: Int,
         quantity: Int,
     ): String {
-        val plural = getPluralFromRepository(id, quantity)
-        val formattedPlural = plural ?: res.getQuantityString(id, quantity)
-
-        savePluralToCopy(id, quantity, formattedPlural)
-
-        return formattedPlural
+        return try {
+            val plural = getPluralFromRepository(id, quantity)
+            val formattedPlural = plural ?: res.getQuantityString(id, quantity)
+            savePluralToCopy(id, quantity, formattedPlural)
+            formattedPlural
+        } catch (_: NotFoundException) {
+            super.getQuantityString(id, quantity)
+        }
     }
 
     override fun toString(): String = res.toString()

--- a/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
@@ -43,11 +43,14 @@ internal class CrowdinResources(
     ) {
     @Throws(NotFoundException::class)
     override fun getString(id: Int): String {
-        val entryName = getResourceEntryName(id)
-        val string = getStringFromRepository(id)?.replaceNewLine() ?: res.getString(id)
-        saveStringDataToCopy(entryName, string)
-
-        return string
+        return try {
+            val entryName = getResourceEntryName(id)
+            val string = getStringFromRepository(id)?.replaceNewLine() ?: res.getString(id)
+            saveStringDataToCopy(entryName, string)
+            string
+        } catch (_: NotFoundException) {
+            super.getString(id)
+        }
     }
 
     @Throws(NotFoundException::class)
@@ -55,53 +58,64 @@ internal class CrowdinResources(
         id: Int,
         vararg formatArgs: Any,
     ): String {
-        val entryName = getResourceEntryName(id)
-        val string = getStringFromRepository(id)?.replaceNewLine()
-        val formattedString =
-            if (string == null) {
-                res.getString(id, *formatArgs)
-            } else {
-                try {
-                    String.format(string, *formatArgs)
-                } catch (_: Exception) {
+        return try {
+            val entryName = getResourceEntryName(id)
+            val string = getStringFromRepository(id)?.replaceNewLine()
+            val formattedString =
+                if (string == null) {
                     res.getString(id, *formatArgs)
+                } else {
+                    try {
+                        String.format(string, *formatArgs)
+                    } catch (_: Exception) {
+                        res.getString(id, *formatArgs)
+                    }
                 }
-            }
-
-        saveStringDataToCopy(entryName, formattedString, formatArgs)
-
-        return formattedString
+            saveStringDataToCopy(entryName, formattedString, formatArgs)
+            formattedString
+        } catch (_: NotFoundException) {
+            super.getString(id, *formatArgs)
+        }
     }
 
     @Throws(NotFoundException::class)
     override fun getStringArray(id: Int): Array<String> {
-        val entryName = getResourceEntryName(id)
-        val stringArray = getStringArrayFromRepository(id) ?: res.getStringArray(id)
-        saveStringArrayDataToCopy(entryName, stringArray)
-
-        return stringArray
+        return try {
+            val entryName = getResourceEntryName(id)
+            val stringArray = getStringArrayFromRepository(id) ?: res.getStringArray(id)
+            saveStringArrayDataToCopy(entryName, stringArray)
+            stringArray
+        } catch (_: NotFoundException) {
+            super.getStringArray(id)
+        }
     }
 
     @Throws(NotFoundException::class)
     override fun getText(id: Int): CharSequence {
-        val entryName = getResourceEntryName(id)
-        val string = getStringFromRepository(id)
-        val formattedString = string?.fromHtml() ?: res.getText(id)
-        saveStringDataToCopy(entryName, formattedString.toString())
-
-        return formattedString
+        return try {
+            val entryName = getResourceEntryName(id)
+            val string = getStringFromRepository(id)
+            val formattedString = string?.fromHtml() ?: res.getText(id)
+            saveStringDataToCopy(entryName, formattedString.toString())
+            formattedString
+        } catch (_: NotFoundException) {
+            super.getText(id)
+        }
     }
 
     override fun getText(
         id: Int,
         default: CharSequence,
     ): CharSequence {
-        val entryName = getResourceEntryName(id)
-        val string = getStringFromRepository(id)
-        val formattedString = string?.fromHtml() ?: res.getText(id, default)
-        saveStringDataToCopy(entryName, formattedString.toString(), default = default)
-
-        return formattedString
+        return try {
+            val entryName = getResourceEntryName(id)
+            val string = getStringFromRepository(id)
+            val formattedString = string?.fromHtml() ?: res.getText(id, default)
+            saveStringDataToCopy(entryName, formattedString.toString(), default = default)
+            formattedString
+        } catch (_: NotFoundException) {
+            super.getText(id, default)
+        }
     }
 
     @Throws(NotFoundException::class)
@@ -356,7 +370,11 @@ internal class CrowdinResources(
         defaultText: String,
         formatArgs: Array<out Any?> = arrayOf(),
     ) {
-        val entryName = getResourceEntryName(id)
+        val entryName = try {
+            getResourceEntryName(id)
+        } catch (_: NotFoundException) {
+            return
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val rule = PluralRules.forLocale(configuration.getLocale())
             val ruleName = rule.select(quantity.toDouble())
@@ -383,10 +401,13 @@ internal class CrowdinResources(
         }
 
     private fun getStringArrayFromRepository(id: Int): Array<String>? {
-        val entryName = getResourceEntryName(id)
-        val localeCode = configuration.getLocale().getFormattedCode()
-
-        return dataManager.getStringArray(localeCode, entryName)
+        return try {
+            val entryName = getResourceEntryName(id)
+            val localeCode = configuration.getLocale().getFormattedCode()
+            dataManager.getStringArray(localeCode, entryName)
+        } catch (_: NotFoundException) {
+            null
+        }
     }
 
     private fun getPluralFromRepository(

--- a/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
@@ -413,15 +413,17 @@ internal class CrowdinResources(
     private fun getPluralFromRepository(
         id: Int,
         quantity: Int,
-    ): String? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            val locale = configuration.getLocale()
-            val localeCode = locale.getFormattedCode()
-            val entryName = getResourceEntryName(id)
-            val rule = PluralRules.forLocale(locale)
-            val ruleName = rule.select(quantity.toDouble())
-            dataManager.getStringPlural(localeCode, entryName, ruleName)
-        } else {
-            null
+    ): String? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return null
+        val locale = configuration.getLocale()
+        val localeCode = locale.getFormattedCode()
+        val entryName = try {
+            getResourceEntryName(id)
+        } catch (_: NotFoundException) {
+            return null
         }
+        val rule = PluralRules.forLocale(locale)
+        val ruleName = rule.select(quantity.toDouble())
+        return dataManager.getStringPlural(localeCode, entryName, ruleName)
+    }
 }


### PR DESCRIPTION
Fixes #347

When WebView (or other system components) call \`getString()\` with their own internal resource IDs, \`CrowdinResources.getResourceEntryName()\` throws \`Resources\$NotFoundException\` because those IDs don't exist in the host app's resource table.

Wrap the resource lookup in a try-catch for \`Resources.NotFoundException\` and fall back to \`super.getString()\` when the resource ID is not from the host app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `Resources` wrapper used throughout the app; while the change is mainly defensive exception handling, incorrect fallbacks could subtly alter string/plural resolution behavior in edge cases.
> 
> **Overview**
> Prevents crashes when system components (e.g., `WebView`) call `CrowdinResources` with non-app resource IDs by catching `Resources.NotFoundException` in `getString`, `getString(vararg)`, `getStringArray`, and `getText`, and falling back to `super` implementations.
> 
> Also hardens repository/plural handling by skipping reserve-resource persistence when an entry name can’t be resolved (`savePluralToCopy`) and returning `null` from repository lookups (`getStringArrayFromRepository`, `getPluralFromRepository`) when the ID isn’t found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e557ae06741225545b6adf327adc6e3ea60e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->