### PR TITLE
fix: resolve es-419 for Latin American Spanish device locales

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
@@ -20,6 +20,34 @@ const val NEW_LINE = "<br>"
 private const val DEFAULT_DATE_TIME_FORMAT = "yyyy_MM_dd-HH_mm_ss"
 private val crowdinCodeMapping = mapOf("iw" to "he", "in" to "id")
 
+// Regions whose Spanish locales fall back to the es-419 group per CLDR parent-locale
+// data, mirroring Android resource resolution (es-MX -> es-419 -> es).
+private val es419Regions =
+    setOf(
+        "AR",
+        "BO",
+        "BR",
+        "BZ",
+        "CL",
+        "CO",
+        "CR",
+        "CU",
+        "DO",
+        "EC",
+        "GT",
+        "HN",
+        "MX",
+        "NI",
+        "PA",
+        "PE",
+        "PR",
+        "PY",
+        "SV",
+        "US",
+        "UY",
+        "VE",
+    )
+
 fun MenuInflater.inflateWithCrowdin(
     @MenuRes menuRes: Int,
     menu: Menu,
@@ -73,9 +101,18 @@ fun getMatchedCode(
     }
 
     if (list?.contains(code) == false) {
+        val parentCode = code.getParentLocaleCode()
+        if (parentCode != null && list.contains(parentCode)) {
+            return parentCode
+        }
         return languageCode.takeIf { list.contains(languageCode) }
     }
     return code
+}
+
+internal fun String.getParentLocaleCode(): String? {
+    val parts = split("-")
+    return if (parts.size == 2 && parts[0] == "es" && parts[1] in es419Regions) "es-419" else null
 }
 
 fun String.withCrowdinSupportedCheck(): String = crowdinCodeMapping[this] ?: this

--- a/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
@@ -101,16 +101,16 @@ fun getMatchedCode(
     }
 
     if (list?.contains(code) == false) {
-        val parentCode = code.getParentLocaleCode()
-        if (parentCode != null && list.contains(parentCode)) {
-            return parentCode
+        val es419Code = code.getEs419FallbackCode()
+        if (es419Code != null && list.contains(es419Code)) {
+            return es419Code
         }
         return languageCode.takeIf { list.contains(languageCode) }
     }
     return code
 }
 
-internal fun String.getParentLocaleCode(): String? {
+private fun String.getEs419FallbackCode(): String? {
     val parts = split("-")
     return if (parts.size == 2 && parts[0] == "es" && parts[1] in es419Regions) "es-419" else null
 }

--- a/crowdin/src/test/java/com/crowdin/platform/ExtensionsTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/ExtensionsTest.kt
@@ -1,0 +1,142 @@
+package com.crowdin.platform
+
+import com.crowdin.platform.data.model.LanguageDetails
+import com.crowdin.platform.data.model.SupportedLanguages
+import com.crowdin.platform.util.getMatchedCode
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+class ExtensionsTest {
+    private lateinit var defaultLocale: Locale
+
+    private val supportedLanguages: SupportedLanguages =
+        mapOf(
+            "es" to LanguageDetails("Spanish", "es-ES"),
+            "es-419" to LanguageDetails("Spanish, Latin America", "es-419"),
+            "fr" to LanguageDetails("French", "fr-FR"),
+        )
+
+    @Before
+    fun setUp() {
+        defaultLocale = Locale.getDefault()
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun whenLatinAmericanSpanishLocaleAndBothSpanishVariantsPresent_shouldMatchEs419() {
+        Locale.setDefault(Locale("es", "MX"))
+
+        val result = getMatchedCode(null, listOf("es", "es-419", "fr"), supportedLanguages)
+
+        assertEquals("es-419", result)
+    }
+
+    @Test
+    fun whenAnyLatinAmericanRegion_shouldMatchEs419() {
+        val latinAmericanRegions =
+            listOf(
+                "AR",
+                "BO",
+                "BR",
+                "BZ",
+                "CL",
+                "CO",
+                "CR",
+                "CU",
+                "DO",
+                "EC",
+                "GT",
+                "HN",
+                "MX",
+                "NI",
+                "PA",
+                "PE",
+                "PR",
+                "PY",
+                "SV",
+                "US",
+                "UY",
+                "VE",
+            )
+
+        latinAmericanRegions.forEach { region ->
+            Locale.setDefault(Locale("es", region))
+
+            val result = getMatchedCode(null, listOf("es", "es-419"), supportedLanguages)
+
+            assertEquals("Region $region should resolve to es-419", "es-419", result)
+        }
+    }
+
+    @Test
+    fun whenCastilianSpanishLocale_shouldMatchEs() {
+        Locale.setDefault(Locale("es", "ES"))
+
+        val result = getMatchedCode(null, listOf("es", "es-419"), supportedLanguages)
+
+        assertEquals("es", result)
+    }
+
+    @Test
+    fun whenLatinAmericanSpanishLocaleAndOnlyEsPresent_shouldFallbackToEs() {
+        Locale.setDefault(Locale("es", "MX"))
+
+        val result = getMatchedCode(null, listOf("es", "fr"), supportedLanguages)
+
+        assertEquals("es", result)
+    }
+
+    @Test
+    fun whenLatinAmericanSpanishLocaleAndOnlyEs419Present_shouldMatchEs419() {
+        Locale.setDefault(Locale("es", "PA"))
+
+        val result = getMatchedCode(null, listOf("es-419", "fr"), supportedLanguages)
+
+        assertEquals("es-419", result)
+    }
+
+    @Test
+    fun whenEuropeanSpanishRegionAndBothSpanishVariantsPresent_shouldNotMatchEs419() {
+        // Equatorial Guinea keeps the default `es` parent in CLDR
+        Locale.setDefault(Locale("es", "GQ"))
+
+        val result = getMatchedCode(null, listOf("es", "es-419"), supportedLanguages)
+
+        assertEquals("es", result)
+    }
+
+    @Test
+    fun whenExactCodePresentInList_shouldMatchExactCode() {
+        Locale.setDefault(Locale("fr", "CA"))
+
+        val result = getMatchedCode(null, listOf("fr", "fr-CA"), supportedLanguages)
+
+        assertEquals("fr-CA", result)
+    }
+
+    @Test
+    fun whenLocaleMatchesSupportedLanguageLocale_shouldReturnLanguageKey() {
+        Locale.setDefault(Locale("fr", "FR"))
+
+        val result = getMatchedCode(null, listOf("es", "fr"), supportedLanguages)
+
+        assertEquals("fr", result)
+    }
+
+    @Test
+    fun whenNoMatch_shouldReturnNull() {
+        Locale.setDefault(Locale("de", "DE"))
+
+        val result = getMatchedCode(null, listOf("es", "fr"), supportedLanguages)
+
+        assertNull(result)
+    }
+}

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -10,7 +10,13 @@ Yes, the SDK caches translations locally. The cache TTL can be configured by the
 
 ## What translations will be displayed if the current locale is not present in the Crowdin project?
 
-The app will use the bundled translations or the default language as a fallback. It will not fall back to any other Crowdin locale.
+The SDK resolves the device locale against the project languages in the following order:
+
+1. Exact locale match (e.g. `es-MX`).
+2. Region group match for Latin American Spanish locales (e.g. `es-MX` → `es-419`).
+3. Two-letter language code match (e.g. `es-MX` → `es`).
+
+If none of these match a project language, the app will use the bundled translations or the default language as a fallback.
 
 ## Will the SDK download all translations from Crowdin every time the app launches?
 


### PR DESCRIPTION
When a project targets both es and es-419, device locales like es-MX or es-PA fell back straight to the bare language subtag and matched es (Castilian). Add a CLDR parent-locale step to getMatchedCode so Latin American Spanish regions resolve to es-419 before falling back to es, mirroring Android resource resolution (es-MX -> es-419 -> es).