### PR TITLE
fix: resolve and apply translations for regional device locales

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/CrowdinResources.kt
@@ -23,7 +23,6 @@ import com.crowdin.platform.data.model.ArrayData
 import com.crowdin.platform.data.model.PluralData
 import com.crowdin.platform.data.model.StringData
 import com.crowdin.platform.util.fromHtml
-import com.crowdin.platform.util.getFormattedCode
 import com.crowdin.platform.util.getLocale
 import com.crowdin.platform.util.replaceNewLine
 import java.io.InputStream
@@ -377,16 +376,19 @@ internal class CrowdinResources(
     private fun getStringFromRepository(id: Int): String? =
         try {
             val entryName = getResourceEntryName(id)
-            dataManager.getString(configuration.getLocale().getFormattedCode(), entryName)
+            dataManager.getLocaleKeys(configuration).firstNotNullOfOrNull {
+                dataManager.getString(it, entryName)
+            }
         } catch (_: NotFoundException) {
             null
         }
 
     private fun getStringArrayFromRepository(id: Int): Array<String>? {
         val entryName = getResourceEntryName(id)
-        val localeCode = configuration.getLocale().getFormattedCode()
 
-        return dataManager.getStringArray(localeCode, entryName)
+        return dataManager.getLocaleKeys(configuration).firstNotNullOfOrNull {
+            dataManager.getStringArray(it, entryName)
+        }
     }
 
     private fun getPluralFromRepository(
@@ -395,11 +397,12 @@ internal class CrowdinResources(
     ): String? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val locale = configuration.getLocale()
-            val localeCode = locale.getFormattedCode()
             val entryName = getResourceEntryName(id)
             val rule = PluralRules.forLocale(locale)
             val ruleName = rule.select(quantity.toDouble())
-            dataManager.getStringPlural(localeCode, entryName, ruleName)
+            dataManager.getLocaleKeys(configuration).firstNotNullOfOrNull {
+                dataManager.getStringPlural(it, entryName, ruleName)
+            }
         } else {
             null
         }

--- a/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/DataManager.kt
@@ -1,6 +1,7 @@
 package com.crowdin.platform.data
 
 import android.content.Context
+import android.content.res.Configuration
 import android.util.Log
 import androidx.annotation.WorkerThread
 import com.crowdin.platform.Crowdin.CROWDIN_TAG
@@ -24,6 +25,8 @@ import com.crowdin.platform.data.remote.RemoteRepository
 import com.crowdin.platform.util.FeatureFlags
 import com.crowdin.platform.util.ThreadUtils
 import com.crowdin.platform.util.getFormattedCode
+import com.crowdin.platform.util.getLocale
+import com.crowdin.platform.util.withCrowdinSupportedCheck
 import com.google.gson.reflect.TypeToken
 import java.lang.reflect.Type
 import java.util.Locale
@@ -113,11 +116,42 @@ internal class DataManager(
 
     fun refreshData(languageData: LanguageData) {
         localRepository.saveLanguageData(languageData)
+        if (languageData.language.isNotEmpty()) {
+            crowdinPreferences.setString(TRANSLATION_LOCALE_KEY, languageData.language)
+        }
+
         if (FeatureFlags.isRealTimeUpdateEnabled || FeatureFlags.isScreenshotEnabled) {
             dataChangeObserver.onDataChanged()
         }
 
         sendOnDataChanged()
+    }
+
+    /**
+     * Locale keys to look translations up under, most specific first.
+     *
+     * Translations are stored under the Crowdin locale of the matched language (`es-419`), while a
+     * device reports its own locale (`es-MX`). Without the second key the lookup asks for `es-MX`,
+     * finds nothing and silently falls back to the bundled strings.
+     */
+    fun getLocaleKeys(configuration: Configuration?): List<String> {
+        val locale = configuration.getLocale()
+        val formattedCode = locale.getFormattedCode()
+        // Preferences return an empty string, not null, for a missing key.
+        val storedKey = crowdinPreferences.getString(TRANSLATION_LOCALE_KEY)
+        if (storedKey.isNullOrEmpty() || storedKey == formattedCode) {
+            return listOf(formattedCode)
+        }
+
+        // Fall back to the stored key only while it belongs to the language currently being
+        // displayed, otherwise a locale switch would serve the previously downloaded language.
+        val language = locale.language.withCrowdinSupportedCheck()
+
+        return if (storedKey.substringBefore('-') == language) {
+            listOf(formattedCode, storedKey)
+        } else {
+            listOf(formattedCode)
+        }
     }
 
     private fun validateData(
@@ -329,6 +363,7 @@ internal class DataManager(
         const val CACHED_LANGUAGES = "cached_languages"
         const val MANIFEST_DATA = "manifest_data"
         const val SYNC_DATA = "sync_data"
+        const val TRANSLATION_LOCALE_KEY = "translation_locale_key"
         const val EVENT_TICKETS = "event_tickets"
         const val EVENT_TICKETS_EXPIRATION = 1000 * 60 * 4
     }

--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
@@ -74,14 +74,11 @@ internal class StringDataRemoteRepository(
 
         // Combine all data before save to storage
         val languageData = LanguageData()
-        val languageInfo = getLanguageInfo(preferredLanguageCode)
 
-        if (languageInfo == null) {
-            languageDataCallback?.onFailure(Throwable("Language info not found for $preferredLanguageCode"))
-            return
-        }
+        // The cached language list is fetched separately from the manifest and can lag behind a
+        // language the manifest already ships. The Crowdin code works as a storage key on its own.
+        languageData.language = getLanguageInfo(preferredLanguageCode)?.locale ?: preferredLanguageCode
 
-        languageData.language = languageInfo.locale
         manifest?.content?.get(preferredLanguageCode)?.forEach { filePath ->
             val eTag = eTagMap[filePath]
             val result =

--- a/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
@@ -18,7 +18,51 @@ import java.util.TimeZone
 
 const val NEW_LINE = "<br>"
 private const val DEFAULT_DATE_TIME_FORMAT = "yyyy_MM_dd-HH_mm_ss"
-private val crowdinCodeMapping = mapOf("iw" to "he", "in" to "id")
+
+// Android reports the obsolete ISO 639 codes for these languages, Crowdin uses the current ones.
+private val crowdinCodeMapping = mapOf("iw" to "he", "in" to "id", "ji" to "yi")
+
+private const val SCRIPT_HANS = "Hans"
+private const val SCRIPT_HANT = "Hant"
+private const val SCRIPT_LATIN = "Latn"
+
+/*
+ * CLDR parent-locale data (`supplementalData.xml` -> `parentLocales`). Android resolves bundled
+ * resources through the same table, so the SDK mirrors it to land on the translation a user would
+ * actually see: es-MX -> es-419 -> es instead of es-MX -> es.
+ */
+private val es419Regions =
+    setOf(
+        "AR",
+        "BO",
+        "BR",
+        "BZ",
+        "CL",
+        "CO",
+        "CR",
+        "CU",
+        "DO",
+        "EC",
+        "GT",
+        "HN",
+        "MX",
+        "NI",
+        "PA",
+        "PE",
+        "PR",
+        "PY",
+        "SV",
+        "US",
+        "UY",
+        "VE",
+    )
+
+// CLDR treats `pt-BR`, not `pt-PT`, as the root Portuguese.
+private val ptPtRegions = setOf("AO", "CH", "CV", "FR", "GQ", "GW", "LU", "MO", "MZ", "ST", "TL")
+
+// Used to infer the script when the locale carries no script subtag.
+private val chineseTraditionalRegions = setOf("HK", "MO", "TW")
+private val chineseSimplifiedRegions = setOf("CN", "SG")
 
 fun MenuInflater.inflateWithCrowdin(
     @MenuRes menuRes: Int,
@@ -61,22 +105,68 @@ fun getMatchedCode(
     list: List<String>?,
     supportedLanguages: SupportedLanguages?,
 ): String? {
-    val languageCode = configuration.getLocale().language.withCrowdinSupportedCheck()
-    val code = "$languageCode-${Locale.getDefault().country}"
+    val locale = configuration.getLocale()
+    val languageCode = locale.language.withCrowdinSupportedCheck()
+    val code = "$languageCode-${locale.country}"
 
+    // `languages.json` and `manifest.json` are cached independently and can disagree, so a
+    // language is only usable when the manifest actually ships content for it.
     if (supportedLanguages != null) {
-        for (languageData in supportedLanguages) {
-            if (languageData.value.locale == code) {
-                return languageData.key
+        for ((crowdinCode, details) in supportedLanguages) {
+            if (details.locale == code && list?.contains(crowdinCode) != false) {
+                return crowdinCode
             }
         }
     }
 
-    if (list?.contains(code) == false) {
-        return languageCode.takeIf { list.contains(languageCode) }
+    if (list == null || list.contains(code)) {
+        return code
     }
-    return code
+
+    locale.parentLocaleCodes(languageCode).firstOrNull { list.contains(it) }?.let { return it }
+
+    return languageCode.takeIf { list.contains(languageCode) }
 }
+
+/**
+ * Crowdin language codes to try between an exact `language-REGION` match and the bare language
+ * subtag, closest CLDR parent first. Empty when the language has no parent-locale group.
+ */
+internal fun Locale.parentLocaleCodes(languageCode: String): List<String> =
+    parentLocaleCodes(languageCode, country.uppercase(Locale.ROOT), scriptCompat())
+
+/** Serbian Latin is `sr-CS` in Crowdin, not the BCP 47 `sr-Latn`. */
+internal fun parentLocaleCodes(
+    languageCode: String,
+    region: String,
+    script: String,
+): List<String> =
+    when (languageCode) {
+        "es" -> if (region in es419Regions) listOf("es-419") else emptyList()
+        "pt" -> if (region in ptPtRegions) listOf("pt-PT") else emptyList()
+        "zh" -> chineseParentCodes(region, script)
+        "sr" -> if (script == SCRIPT_LATIN) listOf("sr-CS") else emptyList()
+        else -> emptyList()
+    }
+
+/** CLDR chains zh-Hant-MO through zh-Hant-HK before reaching zh-Hant. */
+private fun chineseParentCodes(
+    region: String,
+    script: String,
+): List<String> {
+    val traditional = script == SCRIPT_HANT || (script.isEmpty() && region in chineseTraditionalRegions)
+    val simplified = script == SCRIPT_HANS || (script.isEmpty() && region in chineseSimplifiedRegions)
+
+    return when {
+        traditional && region == "MO" -> listOf("zh-HK", "zh-TW")
+        traditional -> listOf("zh-TW")
+        simplified -> listOf("zh-CN")
+        else -> emptyList()
+    }
+}
+
+// Locales cannot carry a script below API 21.
+private fun Locale.scriptCompat(): String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) script else ""
 
 fun String.withCrowdinSupportedCheck(): String = crowdinCodeMapping[this] ?: this
 

--- a/crowdin/src/test/java/com/crowdin/platform/LocaleKeysTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/LocaleKeysTest.kt
@@ -1,0 +1,148 @@
+package com.crowdin.platform
+
+import android.content.res.Configuration
+import com.crowdin.platform.data.DataManager
+import com.crowdin.platform.data.local.LocalRepository
+import com.crowdin.platform.data.model.LanguageData
+import com.crowdin.platform.data.remote.RemoteRepository
+import com.crowdin.platform.util.FeatureFlags
+import com.crowdin.platform.util.getFormattedCode
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import java.util.Locale
+
+/**
+ * The lookup key used at runtime has to point at the key the translations were actually stored
+ * under, otherwise a matched language is downloaded and then never read.
+ */
+class LocaleKeysTest {
+    private lateinit var mockLocalRepository: LocalRepository
+    private lateinit var mockRemoteRepository: RemoteRepository
+    private lateinit var mockPreferences: Preferences
+    private lateinit var mockLocalDataChangeObserver: LocalDataChangeObserver
+    private lateinit var dataManager: DataManager
+    private lateinit var defaultLocale: Locale
+
+    @Before
+    fun setUp() {
+        defaultLocale = Locale.getDefault()
+        mockLocalRepository = mock(LocalRepository::class.java)
+        mockRemoteRepository = mock(RemoteRepository::class.java)
+        mockPreferences = mock(Preferences::class.java)
+        mockLocalDataChangeObserver = mock(LocalDataChangeObserver::class.java)
+        dataManager =
+            DataManager(
+                mockRemoteRepository,
+                mockLocalRepository,
+                mockPreferences,
+                mockLocalDataChangeObserver,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    private fun configurationOf(locale: Locale): Configuration {
+        val configuration = Configuration()
+
+        @Suppress("DEPRECATION")
+        configuration.locale = locale
+
+        return configuration
+    }
+
+    private fun givenStoredKey(key: String?) {
+        `when`(mockPreferences.getString(DataManager.TRANSLATION_LOCALE_KEY)).thenReturn(key)
+    }
+
+    @Test
+    fun whenNothingStoredYet_shouldOnlyUseTheFormattedDeviceCode() {
+        givenStoredKey(null)
+
+        assertEquals(listOf("es-MX"), dataManager.getLocaleKeys(configurationOf(Locale("es", "MX"))))
+    }
+
+    @Test
+    fun whenNothingStoredYetAndPreferencesReturnEmpty_shouldOnlyUseTheFormattedDeviceCode() {
+        // CrowdinPreferences defaults a missing key to an empty string rather than null.
+        givenStoredKey("")
+
+        assertEquals(listOf("es-MX"), dataManager.getLocaleKeys(configurationOf(Locale("es", "MX"))))
+    }
+
+    @Test
+    fun whenStoredKeyIsForTheSameLanguage_shouldFallBackToIt() {
+        givenStoredKey("es-419")
+
+        assertEquals(listOf("es-MX", "es-419"), dataManager.getLocaleKeys(configurationOf(Locale("es", "MX"))))
+    }
+
+    @Test
+    fun whenStoredKeyIsTheCanonicalRegion_shouldFallBackToIt() {
+        // Project targets German only; an Austrian device must still read the German translations.
+        givenStoredKey("de-DE")
+
+        assertEquals(listOf("de-AT", "de-DE"), dataManager.getLocaleKeys(configurationOf(Locale("de", "AT"))))
+    }
+
+    @Test
+    fun whenStoredKeyIsForAnotherLanguage_shouldNotBeUsed() {
+        // Locale switched after the last sync: keep serving bundled French, never stale Spanish.
+        givenStoredKey("es-419")
+
+        assertEquals(listOf("fr-FR"), dataManager.getLocaleKeys(configurationOf(Locale("fr", "FR"))))
+    }
+
+    @Test
+    fun whenStoredKeyEqualsTheFormattedCode_shouldNotBeDuplicated() {
+        givenStoredKey("es-ES")
+
+        assertEquals(listOf("es-ES"), dataManager.getLocaleKeys(configurationOf(Locale("es", "ES"))))
+    }
+
+    @Test
+    fun whenLanguageUsesALegacyAndroidCode_shouldStillMatchTheStoredKey() {
+        // Android reports Hebrew as `iw`; Crowdin stores it as `he`.
+        givenStoredKey("he-IL")
+
+        assertEquals(listOf("he-IL"), dataManager.getLocaleKeys(configurationOf(Locale("iw", "IL"))))
+    }
+
+    @Test
+    fun theDeviceCodeIsAlwaysTriedFirst() {
+        // Guarantees a lookup that resolves today cannot start resolving somewhere else.
+        givenStoredKey("es-419")
+
+        listOf(Locale("es", "MX"), Locale("es", "ES"), Locale("es")).forEach { locale ->
+            val keys = dataManager.getLocaleKeys(configurationOf(locale))
+
+            assertEquals(locale.toString(), locale.getFormattedCode(), keys.first())
+        }
+    }
+
+    @Test
+    fun refreshData_shouldRememberTheKeyTranslationsWereStoredUnder() {
+        FeatureFlags.registerConfig(mock(CrowdinConfig::class.java))
+
+        dataManager.refreshData(LanguageData("es-419"))
+
+        verify(mockPreferences).setString(DataManager.TRANSLATION_LOCALE_KEY, "es-419")
+    }
+
+    @Test
+    fun refreshData_shouldIgnoreAnEmptyLanguage() {
+        FeatureFlags.registerConfig(mock(CrowdinConfig::class.java))
+
+        dataManager.refreshData(LanguageData())
+
+        verifyNoInteractions(mockPreferences)
+    }
+}

--- a/crowdin/src/test/java/com/crowdin/platform/LocaleMatchingTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/LocaleMatchingTest.kt
@@ -1,0 +1,299 @@
+package com.crowdin.platform
+
+import android.content.res.Configuration
+import com.crowdin.platform.data.model.LanguageDetails
+import com.crowdin.platform.data.model.SupportedLanguages
+import com.crowdin.platform.util.getMatchedCode
+import com.crowdin.platform.util.parentLocaleCodes
+import com.crowdin.platform.util.withCrowdinSupportedCheck
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+class LocaleMatchingTest {
+    private lateinit var defaultLocale: Locale
+
+    private val spanishProject: SupportedLanguages =
+        mapOf(
+            "es" to LanguageDetails("Spanish", "es-ES"),
+            "es-419" to LanguageDetails("Spanish, Latin America", "es-419"),
+            "fr" to LanguageDetails("French", "fr-FR"),
+        )
+
+    @Before
+    fun setUp() {
+        defaultLocale = Locale.getDefault()
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    private fun configurationOf(locale: Locale): Configuration {
+        val configuration = Configuration()
+
+        @Suppress("DEPRECATION")
+        configuration.locale = locale
+
+        return configuration
+    }
+
+    @Test
+    fun whenLatinAmericanRegionAndBothSpanishVariantsPresent_shouldMatchEs419() {
+        Locale.setDefault(Locale("es", "MX"))
+
+        assertEquals("es-419", getMatchedCode(null, listOf("es", "es-419", "fr"), spanishProject))
+    }
+
+    @Test
+    fun whenLatinAmericanRegionAndOnlyEsPresent_shouldFallBackToEs() {
+        Locale.setDefault(Locale("es", "PA"))
+
+        assertEquals("es", getMatchedCode(null, listOf("es", "fr"), spanishProject))
+    }
+
+    @Test
+    fun whenLatinAmericanRegionAndOnlyEs419Present_shouldMatchEs419() {
+        Locale.setDefault(Locale("es", "AR"))
+
+        assertEquals("es-419", getMatchedCode(null, listOf("es-419", "fr"), spanishProject))
+    }
+
+    @Test
+    fun whenCastilianRegion_shouldMatchEs() {
+        Locale.setDefault(Locale("es", "ES"))
+
+        assertEquals("es", getMatchedCode(null, listOf("es", "es-419"), spanishProject))
+    }
+
+    @Test
+    fun whenRegionKeepsCastilianParentInCldr_shouldNotMatchEs419() {
+        // Equatorial Guinea, Canary Islands and the Philippines keep the plain `es` parent.
+        listOf("GQ", "IC", "PH").forEach { region ->
+            Locale.setDefault(Locale("es", region))
+
+            assertEquals(
+                "es-$region must not resolve to es-419",
+                "es",
+                getMatchedCode(null, listOf("es", "es-419"), spanishProject),
+            )
+        }
+    }
+
+    @Test
+    fun whenDeviceLocaleIsEs419Itself_shouldMatchExactly() {
+        Locale.setDefault(Locale.forLanguageTag("es-419"))
+
+        assertEquals("es-419", getMatchedCode(null, listOf("es", "es-419"), spanishProject))
+    }
+
+    @Test
+    fun whenProjectAlsoTargetsTheExactRegion_shouldPreferIt() {
+        val project = spanishProject + ("es-MX" to LanguageDetails("Spanish, Mexico", "es-MX"))
+        Locale.setDefault(Locale("es", "MX"))
+
+        assertEquals("es-MX", getMatchedCode(null, listOf("es", "es-419", "es-MX"), project))
+    }
+
+    @Test
+    fun whenSupportedLanguagesIsStale_shouldIgnoreLanguagesTheManifestDoesNotShip() {
+        // languages.json is served from a separate CDN cache and can still advertise a language
+        // that was already removed from the project. Matching it downloads nothing at all.
+        val staleLanguages =
+            mapOf(
+                "es-ES" to LanguageDetails("Spanish", "es-ES"),
+                "es-MX" to LanguageDetails("Spanish, Mexico", "es-MX"),
+                "es-419" to LanguageDetails("Spanish, Latin America", "es-419"),
+            )
+        val freshManifest = listOf("es-ES", "es-419")
+        Locale.setDefault(Locale("es", "MX"))
+
+        assertEquals("es-419", getMatchedCode(null, freshManifest, staleLanguages))
+    }
+
+    @Test
+    fun whenAppAppliedItsOwnLocale_shouldUseThatRegionNotTheDeviceRegion() {
+        // The app pinned Castilian Spanish; the device merely happens to be in Argentina.
+        Locale.setDefault(Locale("es", "AR"))
+
+        val result = getMatchedCode(configurationOf(Locale("es", "ES")), listOf("es", "es-419"), spanishProject)
+
+        assertEquals("es", result)
+    }
+
+    @Test
+    fun whenAppAppliedEs419_shouldMatchEs419ExactlyRegardlessOfDeviceRegion() {
+        Locale.setDefault(Locale("es", "ES"))
+
+        val result =
+            getMatchedCode(
+                configurationOf(Locale.forLanguageTag("es-419")),
+                listOf("es", "es-419"),
+                spanishProject,
+            )
+
+        assertEquals("es-419", result)
+    }
+
+    @Test
+    fun whenChineseRegionHasNoBareZh_shouldResolveThroughScriptParent() {
+        val project =
+            mapOf(
+                "zh-CN" to LanguageDetails("Chinese Simplified", "zh-CN"),
+                "zh-TW" to LanguageDetails("Chinese Traditional", "zh-TW"),
+            )
+        val list = listOf("zh-CN", "zh-TW")
+
+        Locale.setDefault(Locale("zh", "HK"))
+        assertEquals("zh-TW", getMatchedCode(null, list, project))
+
+        Locale.setDefault(Locale("zh", "MO"))
+        assertEquals("zh-TW", getMatchedCode(null, list, project))
+
+        Locale.setDefault(Locale("zh", "SG"))
+        assertEquals("zh-CN", getMatchedCode(null, list, project))
+    }
+
+    @Test
+    fun whenChineseMacauAndHongKongIsTargeted_shouldPreferHongKong() {
+        val project =
+            mapOf(
+                "zh-HK" to LanguageDetails("Chinese Traditional, Hong Kong", "zh-HK"),
+                "zh-TW" to LanguageDetails("Chinese Traditional", "zh-TW"),
+            )
+        Locale.setDefault(Locale("zh", "MO"))
+
+        assertEquals("zh-HK", getMatchedCode(null, listOf("zh-HK", "zh-TW"), project))
+    }
+
+    @Test
+    fun whenPortugueseRegionOutsideBrazil_shouldResolveToPtPt() {
+        val project =
+            mapOf(
+                "pt-PT" to LanguageDetails("Portuguese", "pt-PT"),
+                "pt-BR" to LanguageDetails("Portuguese, Brazilian", "pt-BR"),
+            )
+        Locale.setDefault(Locale("pt", "MZ"))
+
+        assertEquals("pt-PT", getMatchedCode(null, listOf("pt-PT", "pt-BR"), project))
+    }
+
+    @Test
+    fun whenPortugueseBrazil_shouldNotResolveToPtPt() {
+        val project =
+            mapOf(
+                "pt-PT" to LanguageDetails("Portuguese", "pt-PT"),
+                "pt-BR" to LanguageDetails("Portuguese, Brazilian", "pt-BR"),
+            )
+        Locale.setDefault(Locale("pt", "BR"))
+
+        assertEquals("pt-BR", getMatchedCode(null, listOf("pt-PT", "pt-BR"), project))
+    }
+
+    @Test
+    fun parentLocaleCodes_shouldFollowCldrParentLocales() {
+        assertEquals(listOf("pt-PT"), parentLocaleCodes("pt", "MZ", ""))
+        assertEquals(emptyList<String>(), parentLocaleCodes("pt", "BR", ""))
+        assertEquals(emptyList<String>(), parentLocaleCodes("pt", "PT", ""))
+
+        assertEquals(listOf("zh-TW"), parentLocaleCodes("zh", "HK", ""))
+        assertEquals(listOf("zh-HK", "zh-TW"), parentLocaleCodes("zh", "MO", ""))
+        assertEquals(listOf("zh-CN"), parentLocaleCodes("zh", "SG", ""))
+        assertEquals(emptyList<String>(), parentLocaleCodes("zh", "", ""))
+
+        // An explicit script subtag wins over the region default.
+        assertEquals(listOf("zh-CN"), parentLocaleCodes("zh", "HK", "Hans"))
+        assertEquals(listOf("zh-TW"), parentLocaleCodes("zh", "CN", "Hant"))
+
+        assertEquals(listOf("sr-CS"), parentLocaleCodes("sr", "RS", "Latn"))
+        assertEquals(emptyList<String>(), parentLocaleCodes("sr", "RS", "Cyrl"))
+        assertEquals(emptyList<String>(), parentLocaleCodes("sr", "RS", ""))
+
+        assertEquals(emptyList<String>(), parentLocaleCodes("de", "AT", ""))
+        assertEquals(emptyList<String>(), parentLocaleCodes("en", "NZ", ""))
+    }
+
+    @Test
+    fun parentLocaleCodes_es419GroupMatchesCldrExactly() {
+        // CLDR supplementalData.xml: <parentLocale parent="es-419" locales="..."/>
+        val cldrEs419 =
+            setOf(
+                "AR",
+                "BO",
+                "BR",
+                "BZ",
+                "CL",
+                "CO",
+                "CR",
+                "CU",
+                "DO",
+                "EC",
+                "GT",
+                "HN",
+                "MX",
+                "NI",
+                "PA",
+                "PE",
+                "PR",
+                "PY",
+                "SV",
+                "US",
+                "UY",
+                "VE",
+            )
+        val allRegions = Locale.getISOCountries().toSet() + "419"
+
+        allRegions.forEach { region ->
+            val expected = if (region in cldrEs419) listOf("es-419") else emptyList()
+
+            assertEquals("region $region", expected, parentLocaleCodes("es", region, ""))
+        }
+    }
+
+    @Test
+    fun obsoleteAndroidLanguageCodes_shouldMapToCrowdinCodes() {
+        // Android's Locale.getLanguage() returns the pre-1989 codes: `iw` for Hebrew, `in` for
+        // Indonesian and `ji` for Yiddish. Crowdin targets `he`, `id` and `yi`.
+        assertEquals("he", "iw".withCrowdinSupportedCheck())
+        assertEquals("id", "in".withCrowdinSupportedCheck())
+        assertEquals("yi", "ji".withCrowdinSupportedCheck())
+
+        // Current codes pass through untouched.
+        assertEquals("he", "he".withCrowdinSupportedCheck())
+        assertEquals("id", "id".withCrowdinSupportedCheck())
+        assertEquals("yi", "yi".withCrowdinSupportedCheck())
+        assertEquals("es", "es".withCrowdinSupportedCheck())
+    }
+
+    @Test
+    fun whenSupportedLanguageLocaleMatches_shouldReturnLanguageKey() {
+        Locale.setDefault(Locale("fr", "FR"))
+
+        assertEquals("fr", getMatchedCode(null, listOf("es", "fr"), spanishProject))
+    }
+
+    @Test
+    fun whenExactCodePresentInList_shouldMatchExactCode() {
+        Locale.setDefault(Locale("fr", "CA"))
+
+        assertEquals("fr-CA", getMatchedCode(null, listOf("fr", "fr-CA"), spanishProject))
+    }
+
+    @Test
+    fun whenNothingMatches_shouldReturnNull() {
+        Locale.setDefault(Locale("de", "DE"))
+
+        assertNull(getMatchedCode(null, listOf("es", "fr"), spanishProject))
+    }
+
+    @Test
+    fun whenListIsNull_shouldReturnFormattedCode() {
+        Locale.setDefault(Locale("es", "MX"))
+
+        assertEquals("es-MX", getMatchedCode(null, null, null))
+    }
+}

--- a/crowdin/src/test/java/com/crowdin/platform/LocaleResolutionEndToEndTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/LocaleResolutionEndToEndTest.kt
@@ -1,0 +1,168 @@
+package com.crowdin.platform
+
+import android.content.res.Configuration
+import com.crowdin.platform.data.DataManager
+import com.crowdin.platform.data.local.MemoryLocalRepository
+import com.crowdin.platform.data.model.LanguageData
+import com.crowdin.platform.data.model.LanguageDetails
+import com.crowdin.platform.data.model.StringData
+import com.crowdin.platform.data.model.SupportedLanguages
+import com.crowdin.platform.data.remote.RemoteRepository
+import com.crowdin.platform.util.FeatureFlags
+import com.crowdin.platform.util.getMatchedCode
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.lang.reflect.Type
+import java.util.Locale
+
+/**
+ * Guards the contract between the two halves of locale resolution: the language [getMatchedCode]
+ * picks has to be findable under one of the keys [DataManager.getLocaleKeys] asks for. A language
+ * that resolves but cannot be read is the same as no translation at all.
+ */
+class LocaleResolutionEndToEndTest {
+    /** Minimal in-memory [Preferences] so the stored locale key survives within a test. */
+    private class FakePreferences : Preferences {
+        private val strings = mutableMapOf<String, String>()
+
+        override fun setString(
+            key: String,
+            value: String,
+        ) {
+            strings[key] = value
+        }
+
+        // Matches CrowdinPreferences: a missing key reads back as an empty string, not null.
+        override fun getString(key: String): String? = strings[key] ?: ""
+
+        override fun setLastUpdate(lastUpdate: Long) = Unit
+
+        override fun getLastUpdate(): Long = 0L
+
+        override fun saveData(
+            type: String,
+            data: Any?,
+        ) = Unit
+
+        override fun <T> getData(
+            type: String,
+            classType: Type,
+        ): T? = null
+    }
+
+    // The OrangeTheory project from the reported ticket.
+    private val project: SupportedLanguages =
+        mapOf(
+            "ar" to LanguageDetails("Arabic", "ar-SA"),
+            "zh-CN" to LanguageDetails("Chinese Simplified", "zh-CN"),
+            "fr" to LanguageDetails("French", "fr-FR"),
+            "fr-CA" to LanguageDetails("French, Canada", "fr-CA"),
+            "de" to LanguageDetails("German", "de-DE"),
+            "es" to LanguageDetails("Spanish", "es-ES"),
+            "es-419" to LanguageDetails("Spanish, Latin America", "es-419"),
+        )
+    private val manifestLanguages = project.keys.toList()
+
+    private lateinit var defaultLocale: Locale
+
+    @Before
+    fun setUp() {
+        defaultLocale = Locale.getDefault()
+        FeatureFlags.registerConfig(mock(CrowdinConfig::class.java))
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    private fun configurationOf(locale: Locale): Configuration {
+        val configuration = Configuration()
+
+        @Suppress("DEPRECATION")
+        configuration.locale = locale
+
+        return configuration
+    }
+
+    /**
+     * @param syncLocale locale of the context handed to `Crowdin.init` / `forceUpdate`.
+     * @param readLocale locale of the wrapped activity the strings are read from.
+     * @return the string a user would see, or `null` when the SDK falls back to bundled resources.
+     */
+    private fun translationShownTo(
+        syncLocale: Locale,
+        readLocale: Locale = syncLocale,
+    ): String? {
+        Locale.setDefault(syncLocale)
+
+        val dataManager =
+            DataManager(
+                mock(RemoteRepository::class.java),
+                MemoryLocalRepository(),
+                FakePreferences(),
+                mock(LocalDataChangeObserver::class.java),
+            )
+
+        val matched = getMatchedCode(configurationOf(syncLocale), manifestLanguages, project)
+        if (matched != null) {
+            val languageData = LanguageData(project.getValue(matched).locale)
+            languageData.resources.add(StringData("greeting", "greeting from $matched"))
+            dataManager.refreshData(languageData)
+        }
+
+        return dataManager.getLocaleKeys(configurationOf(readLocale)).firstNotNullOfOrNull {
+            dataManager.getString(it, "greeting")
+        }
+    }
+
+    @Test
+    fun latinAmericanDeviceReadsLatinAmericanSpanish() {
+        assertEquals("greeting from es-419", translationShownTo(Locale("es", "MX")))
+        assertEquals("greeting from es-419", translationShownTo(Locale("es", "PA")))
+        assertEquals("greeting from es-419", translationShownTo(Locale("es", "AR")))
+    }
+
+    @Test
+    fun castilianDeviceReadsCastilianSpanish() {
+        assertEquals("greeting from es", translationShownTo(Locale("es", "ES")))
+    }
+
+    @Test
+    fun deviceRegionWithoutItsOwnTranslationReadsTheLanguageTranslation() {
+        // Austria has no dedicated target language, so the German translation has to be readable
+        // even though it is stored under de-DE.
+        assertEquals("greeting from de", translationShownTo(Locale("de", "AT")))
+    }
+
+    @Test
+    fun regionsMatchingTheirCrowdinLocaleKeepWorking() {
+        assertEquals("greeting from de", translationShownTo(Locale("de", "DE")))
+        assertEquals("greeting from fr", translationShownTo(Locale("fr", "FR")))
+        assertEquals("greeting from fr-CA", translationShownTo(Locale("fr", "CA")))
+        assertEquals("greeting from zh-CN", translationShownTo(Locale("zh", "CN")))
+    }
+
+    @Test
+    fun activityPinnedToEs419ReadsLatinAmericanSpanish() {
+        // The workaround some integrations apply in `attachBaseContext`.
+        val shown = translationShownTo(syncLocale = Locale("es", "PA"), readLocale = Locale.forLanguageTag("es-419"))
+
+        assertEquals("greeting from es-419", shown)
+    }
+
+    @Test
+    fun languageOutsideTheProjectFallsBackToBundledResources() {
+        assertEquals(null, translationShownTo(Locale("pl", "PL")))
+    }
+
+    @Test
+    fun localeSwitchedAfterSyncDoesNotServeThePreviousLanguage() {
+        val shown = translationShownTo(syncLocale = Locale("es", "MX"), readLocale = Locale("fr", "FR"))
+
+        assertEquals(null, shown)
+    }
+}

--- a/crowdin/src/test/java/com/crowdin/platform/StringDataRemoteRepositoryTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/StringDataRemoteRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.crowdin.platform
 
 import com.crowdin.platform.data.LanguageDataCallback
+import com.crowdin.platform.data.model.LanguageData
 import com.crowdin.platform.data.model.LanguageDetails
 import com.crowdin.platform.data.model.SupportedLanguages
 import com.crowdin.platform.data.parser.Reader
@@ -8,6 +9,9 @@ import com.crowdin.platform.data.remote.StringDataRemoteRepository
 import com.crowdin.platform.data.remote.api.CrowdinApi
 import com.crowdin.platform.data.remote.api.CrowdinDistributionApi
 import okhttp3.ResponseBody
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers
@@ -16,19 +20,27 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import retrofit2.Call
 import retrofit2.Response
+import java.util.Locale
 
 class StringDataRemoteRepositoryTest {
     private lateinit var mockDistributionApi: CrowdinDistributionApi
     private lateinit var mockCrowdinApi: CrowdinApi
     private lateinit var mockReader: Reader
     private lateinit var mockCallback: LanguageDataCallback
+    private lateinit var defaultLocale: Locale
 
     @Before
     fun setUp() {
+        defaultLocale = Locale.getDefault()
         mockDistributionApi = mock(CrowdinDistributionApi::class.java)
         mockCrowdinApi = mock(CrowdinApi::class.java)
         mockReader = mock(Reader::class.java)
         mockCallback = mock(LanguageDataCallback::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
     }
 
     @Test
@@ -87,6 +99,43 @@ class StringDataRemoteRepositoryTest {
 
         // Then
         verify(mockCallback).onFailure(any())
+    }
+
+    @Test
+    fun whenLanguageIsInCachedList_shouldStoreUnderItsCrowdinLocale() {
+        // Given
+        val repository = givenStringDataRemoteRepository()
+        repository.crowdinLanguages = mapOf("de" to LanguageDetails("German", "de-DE"))
+        givenMockResponse()
+        Locale.setDefault(Locale("de", "DE"))
+
+        // When
+        repository.onManifestDataReceived(null, givenManifestData(), mockCallback)
+
+        // Then
+        assertThat(capturedLanguageData().language, `is`("de-DE"))
+    }
+
+    @Test
+    fun whenLanguageIsMissingFromCachedList_shouldStoreUnderTheCrowdinCode() {
+        // Given the cached language list lags behind the manifest, which already ships es-ES
+        val repository = givenStringDataRemoteRepository()
+        repository.crowdinLanguages = mapOf("en" to LanguageDetails("English", "en-US"))
+        givenMockResponse()
+        Locale.setDefault(Locale("es", "ES"))
+
+        // When
+        repository.onManifestDataReceived(null, givenManifestData(), mockCallback)
+
+        // Then
+        assertThat(capturedLanguageData().language, `is`("es-ES"))
+    }
+
+    private fun capturedLanguageData(): LanguageData {
+        val captor = argumentCaptor<LanguageData>()
+        verify(mockCallback).onDataLoaded(capture(captor))
+
+        return captor.value
     }
 
     private fun givenSupportedLanguages(): SupportedLanguages = mapOf("en" to LanguageDetails("English", "en-US"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,5 @@ licenseUrl=https://opensource.org/licenses/MIT
 developerId=mykhailo-nester
 developerName=Mykhailo Nester
 developerEmail=nsmisha.dev@gmail.com
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -10,7 +10,15 @@ Yes, the SDK caches translations locally. The cache TTL can be configured by the
 
 ## What translations will be displayed if the current locale is not present in the Crowdin project?
 
-The app will use the bundled translations or the default language as a fallback. It will not fall back to any other Crowdin locale.
+The SDK resolves the device locale against the project target languages in the following order:
+
+1. Exact locale match — `es-MX` picks the `es-MX` target language.
+2. Parent-locale match, mirroring how Android resolves bundled resources — `es-MX` picks `es-419`, `pt-MZ` picks `pt-PT`, `zh-HK` picks `zh-TW`, `zh-SG` picks `zh-CN`, and a Latin-script Serbian locale picks `sr-CS`.
+3. Language subtag match — `es-MX` picks `es`.
+
+If none of these match a project target language, the app will use the bundled translations or the default language as a fallback. It will not fall back to any other Crowdin locale.
+
+Parent-locale matching follows the [CLDR parent locale](https://github.com/unicode-org/cldr/blob/main/common/supplemental/supplementalData.xml) data, so a device gets the same language it would get from bundled resources. Script-based matching (Traditional vs. Simplified Chinese, Cyrillic vs. Latin Serbian) requires Android 5.0 or higher, because older versions cannot represent a script subtag in a locale.
 
 ## Will the SDK download all translations from Crowdin every time the app launches?
 


### PR DESCRIPTION
- resolve device locales through CLDR parent locales;
- take the language and region from the same locale;
- read translations under the key they were stored with;
- tolerate stale distribution language list;
- #251  map obsolete ji language code to yi;
- document locale resolution order in FAQ;