### PR TITLE
fix: download translation files with a plus sign in the path

### DIFF
--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/MappingRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/MappingRepository.kt
@@ -12,6 +12,7 @@ import com.crowdin.platform.data.model.ManifestData
 import com.crowdin.platform.data.model.SupportedLanguages
 import com.crowdin.platform.data.parser.Reader
 import com.crowdin.platform.data.remote.api.CrowdinDistributionApi
+import com.crowdin.platform.util.encodeDistributionPath
 import com.crowdin.platform.util.executeIO
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -76,7 +77,7 @@ internal class MappingRepository(
                     .getMappingFile(
                         eTag = eTag ?: HEADER_ETAG_EMPTY,
                         distributionHash = distributionHash,
-                        filePath = filePath,
+                        filePath = filePath.encodeDistributionPath(),
                     ).execute()
         }
 

--- a/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/data/remote/StringDataRemoteRepository.kt
@@ -12,6 +12,7 @@ import com.crowdin.platform.data.model.SupportedLanguages
 import com.crowdin.platform.data.model.SyncData
 import com.crowdin.platform.data.parser.ReaderFactory
 import com.crowdin.platform.data.remote.api.CrowdinDistributionApi
+import com.crowdin.platform.util.encodeDistributionPath
 import com.crowdin.platform.util.executeIO
 import com.crowdin.platform.util.getLocale
 import com.crowdin.platform.util.getMatchedCode
@@ -86,6 +87,7 @@ internal class StringDataRemoteRepository(
                     eTag = eTag,
                     distributionHash = distributionHash,
                     filePath = filePath,
+                    languageCode = preferredLanguageCode,
                     timestamp = manifest.timestamp,
                     languageDataCallback = languageDataCallback,
                 )
@@ -114,6 +116,7 @@ internal class StringDataRemoteRepository(
         eTag: String?,
         distributionHash: String,
         filePath: String,
+        languageCode: String,
         timestamp: Long,
         languageDataCallback: LanguageDataCallback?,
     ): LanguageData {
@@ -131,7 +134,7 @@ internal class StringDataRemoteRepository(
                     .getResourceFile(
                         eTag = eTag ?: HEADER_ETAG_EMPTY,
                         distributionHash = distributionHash,
-                        filePath = filePath,
+                        filePath = filePath.encodeDistributionPath(),
                         timeStamp = timestamp,
                     ).execute()
         }
@@ -151,7 +154,7 @@ internal class StringDataRemoteRepository(
 
             code == HttpURLConnection.HTTP_FORBIDDEN -> {
                 val errorMessage =
-                    "Translation file $filePath for locale $preferredLanguageCode not found in the distribution"
+                    "Translation file $filePath for locale $languageCode not found in the distribution"
                 Log.e(Crowdin.CROWDIN_TAG, errorMessage)
                 languageDataCallback?.onFailure(Throwable(errorMessage))
             }

--- a/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
+++ b/crowdin/src/main/java/com/crowdin/platform/util/Extensions.kt
@@ -168,6 +168,12 @@ private fun chineseParentCodes(
 // Locales cannot carry a script below API 21.
 private fun Locale.scriptCompat(): String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) script else ""
 
+/**
+ * Manifest paths reach the distribution unencoded, and the CDN answers 403 for a literal `+`.
+ * Android BCP 47 resource folders are the case that matters: `values-b+es+419`.
+ */
+fun String.encodeDistributionPath(): String = replace("+", "%2B")
+
 fun String.withCrowdinSupportedCheck(): String = crowdinCodeMapping[this] ?: this
 
 fun String.unEscapeQuotes(): String =

--- a/crowdin/src/test/java/com/crowdin/platform/LocaleMatchingTest.kt
+++ b/crowdin/src/test/java/com/crowdin/platform/LocaleMatchingTest.kt
@@ -3,6 +3,7 @@ package com.crowdin.platform
 import android.content.res.Configuration
 import com.crowdin.platform.data.model.LanguageDetails
 import com.crowdin.platform.data.model.SupportedLanguages
+import com.crowdin.platform.util.encodeDistributionPath
 import com.crowdin.platform.util.getMatchedCode
 import com.crowdin.platform.util.parentLocaleCodes
 import com.crowdin.platform.util.withCrowdinSupportedCheck
@@ -251,6 +252,30 @@ class LocaleMatchingTest {
             val expected = if (region in cldrEs419) listOf("es-419") else emptyList()
 
             assertEquals("region $region", expected, parentLocaleCodes("es", region, ""))
+        }
+    }
+
+    @Test
+    fun encodeDistributionPath_shouldEncodeBcp47ResourceFolders() {
+        // A literal `+` on the wire comes back as 403 from the distribution.
+        assertEquals(
+            "/content/app/src/main/res/values-b%2Bes%2B419/strings.xml",
+            "/content/app/src/main/res/values-b+es+419/strings.xml".encodeDistributionPath(),
+        )
+        assertEquals(
+            "/content/values-b%2Bsr%2BLatn/strings.xml",
+            "/content/values-b+sr+Latn/strings.xml".encodeDistributionPath(),
+        )
+    }
+
+    @Test
+    fun encodeDistributionPath_shouldLeavePlainPathsUntouched() {
+        listOf(
+            "/content/app/src/main/res/values-es-rES/strings.xml",
+            "/content/es-419/strings.xml",
+            "/mapping/app/src/main/res/values-en-rUS/strings.xml",
+        ).forEach { path ->
+            assertEquals(path, path.encodeDistributionPath())
         }
     }
 


### PR DESCRIPTION
- percent-encode `+` before requesting a file from the distribution;